### PR TITLE
ypdf rendering: make font/text-span first-class flyweight prims

### DIFF
--- a/include/yetty/ypaint-core/buffer.h
+++ b/include/yetty/ypaint-core/buffer.h
@@ -115,25 +115,21 @@ struct yetty_ypaint_core_primitive_iter_result yetty_ypaint_core_buffer_prim_nex
     const struct yetty_ypaint_core_primitive_iter *iter);
 
 /*=============================================================================
- * Font blob storage
+ * Producer convenience: pack flyweight FONT and TEXT_SPAN prims into the
+ * buffer. These are thin wrappers — same path as add_prim. Readers iterate
+ * via the flyweight registry; the canvas dispatches by prim type.
  *===========================================================================*/
 
-/* Add font TTF data to buffer. Returns fontId for use in text spans. */
+/* Pack a FONT primitive (font-prim.h). Returns the producer-assigned
+ * font_id (consecutive, starts at 0). Text spans reference fonts by this
+ * id. */
 struct yetty_ycore_int_result
 yetty_ypaint_core_buffer_add_font(struct yetty_ypaint_core_buffer *buf,
                                   const struct yetty_ycore_buffer *ttf_data,
                                   const char *name);
 
-uint32_t yetty_ypaint_core_buffer_font_count(
-    const struct yetty_ypaint_core_buffer *buf);
-
-const struct yetty_font_blob *yetty_ypaint_core_buffer_get_font(
-    const struct yetty_ypaint_core_buffer *buf, uint32_t index);
-
-/*=============================================================================
- * Text span storage
- *===========================================================================*/
-
+/* Pack a TEXT_SPAN primitive (text-span-prim.h). font_id must match a
+ * previously-added FONT prim's id, or be -1 to use the canvas default. */
 struct yetty_ycore_void_result
 yetty_ypaint_core_buffer_add_text(struct yetty_ypaint_core_buffer *buf,
                                   float x, float y,
@@ -141,12 +137,6 @@ yetty_ypaint_core_buffer_add_text(struct yetty_ypaint_core_buffer *buf,
                                   float font_size, uint32_t color,
                                   uint32_t layer, int32_t font_id,
                                   float rotation);
-
-uint32_t yetty_ypaint_core_buffer_text_span_count(
-    const struct yetty_ypaint_core_buffer *buf);
-
-const struct yetty_text_span *yetty_ypaint_core_buffer_get_text_span(
-    const struct yetty_ypaint_core_buffer *buf, uint32_t index);
 
 #ifdef __cplusplus
 }

--- a/include/yetty/ypaint-core/complex-prim-types.h
+++ b/include/yetty/ypaint-core/complex-prim-types.h
@@ -23,10 +23,16 @@ extern "C" {
 // Complex primitive type IDs (0x80000000+ to avoid collision with SDF 0-255)
 //=============================================================================
 
+/* Tier ranges for ypaint primitive types:
+ *   [0x00000000, 0x000000FF]   Simple SDF (fixed-size, generated)
+ *   [0x40000000, 0x7FFFFFFF]   Flyweight (variable-size, no GPU pipeline)
+ *                                FONT       — yetty/ypaint-core/font-prim.h
+ *                                TEXT_SPAN  — yetty/ypaint-core/text-span-prim.h
+ *   [0x80000000, 0xFFFFFFFF]   Complex (factory + per-instance GPU resources)
+ *                                each concrete factory owns its own type id
+ *                                (e.g. YETTY_YPLOT_TYPE_ID in yplot-gen.h).
+ */
 #define YETTY_YPAINT_COMPLEX_TYPE_BASE   0x80000000u
-#define YETTY_YPAINT_TYPE_FONT           0x80000001u
-#define YETTY_YPAINT_TYPE_TEXT_SPAN      0x80000002u
-#define YETTY_YPAINT_TYPE_YPLOT          0x80000003u
 
 //=============================================================================
 // Complex primitive header (FAM wire format)

--- a/include/yetty/ypaint-core/font-prim.h
+++ b/include/yetty/ypaint-core/font-prim.h
@@ -1,0 +1,70 @@
+#ifndef YETTY_YPAINT_CORE_FONT_PRIM_H
+#define YETTY_YPAINT_CORE_FONT_PRIM_H
+
+/*
+ * font-prim - flyweight primitive carrying TTF bytes through a ypaint buffer.
+ *
+ * Tier:
+ *   Simple (SDF, fixed-size):    [0x00, 0xFF]
+ *   Flyweight (variable-size):   [0x40000000, 0x7FFFFFFF]   ← font/text-span
+ *   Complex (factory + GPU):     [0x80000000, 0xFFFFFFFF]   ← yplot, yimage, …
+ *
+ * A font primitive is just bytes in the buffer's stream — it has no per-instance
+ * GPU state. The canvas materializes it during add_buffer (writes TTF to the
+ * yetty cache, generates an MSDF CDB on miss, opens it as a font).
+ *
+ * Wire layout (little-endian, 4-byte aligned):
+ *   u32 type           (= YETTY_YPAINT_TYPE_FONT)
+ *   u32 payload_size   (bytes of payload, padded to 4)
+ *   i32 font_id        (producer-assigned id; text spans reference it)
+ *   u32 name_len       (bytes; not NUL-terminated)
+ *   u8  name[name_len]
+ *   u32 ttf_len
+ *   u8  ttf[ttf_len]
+ *   u8  pad[0..3]      (so total prim size is 4-aligned)
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <yetty/ypaint-core/flyweight.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define YETTY_YPAINT_TYPE_FONT 0x40000001u
+
+struct yetty_ypaint_font_prim_view {
+	int32_t font_id;
+	const char *name;       /* NOT NUL-terminated, len in name_len */
+	uint32_t name_len;
+	const uint8_t *ttf;
+	uint32_t ttf_len;
+};
+
+/* Size in bytes of a packed FONT prim including the 8-byte FAM header
+ * and trailing alignment padding. */
+size_t yetty_ypaint_font_prim_size_for(uint32_t name_len, uint32_t ttf_len);
+
+/* Pack a FONT prim into out. out must have at least
+ * yetty_ypaint_font_prim_size_for(name_len, ttf_len) bytes. */
+void yetty_ypaint_font_prim_write(uint8_t *out,
+                                  int32_t font_id,
+                                  const char *name, uint32_t name_len,
+                                  const uint8_t *ttf, uint32_t ttf_len);
+
+/* Parse a FONT prim. The view points into the prim payload — lifetime is
+ * tied to the underlying buffer. Returns 0 on success, -1 on malformed. */
+int yetty_ypaint_font_prim_parse(const uint32_t *prim,
+                                 struct yetty_ypaint_font_prim_view *out);
+
+/* Flyweight base ops handler. Returns ops only for type FONT. Register
+ * via yetty_ypaint_flyweight_registry_add(reg, FONT, FONT, handler). */
+struct yetty_ypaint_prim_base_ops_ptr_result
+yetty_ypaint_font_prim_handler(uint32_t prim_type);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* YETTY_YPAINT_CORE_FONT_PRIM_H */

--- a/include/yetty/ypaint-core/text-span-prim.h
+++ b/include/yetty/ypaint-core/text-span-prim.h
@@ -1,0 +1,64 @@
+#ifndef YETTY_YPAINT_CORE_TEXT_SPAN_PRIM_H
+#define YETTY_YPAINT_CORE_TEXT_SPAN_PRIM_H
+
+/*
+ * text-span-prim - flyweight primitive carrying a UTF-8 text run.
+ *
+ * Sits in the same flyweight tier as font-prim. The canvas expands a
+ * TEXT_SPAN into glyph SDF prims at add_buffer time, after fonts have
+ * been materialized.
+ *
+ * Wire layout (little-endian, 4-byte aligned):
+ *   u32 type            (= YETTY_YPAINT_TYPE_TEXT_SPAN)
+ *   u32 payload_size    (bytes of payload, padded to 4)
+ *   f32 x, y, font_size, rotation
+ *   u32 color           (RGBA, R in low byte)
+ *   u32 layer
+ *   i32 font_id         (must match a FONT prim's font_id, or -1 = default)
+ *   u32 text_len
+ *   u8  text[text_len]  (UTF-8)
+ *   u8  pad[0..3]
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <yetty/ypaint-core/flyweight.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define YETTY_YPAINT_TYPE_TEXT_SPAN 0x40000002u
+
+struct yetty_ypaint_text_span_prim_view {
+	float x, y;
+	float font_size;
+	float rotation;
+	uint32_t color;
+	uint32_t layer;
+	int32_t font_id;
+	const char *text;       /* NOT NUL-terminated, len in text_len */
+	uint32_t text_len;
+};
+
+size_t yetty_ypaint_text_span_prim_size_for(uint32_t text_len);
+
+void yetty_ypaint_text_span_prim_write(uint8_t *out,
+                                       float x, float y,
+                                       float font_size, float rotation,
+                                       uint32_t color, uint32_t layer,
+                                       int32_t font_id,
+                                       const char *text, uint32_t text_len);
+
+int yetty_ypaint_text_span_prim_parse(
+	const uint32_t *prim,
+	struct yetty_ypaint_text_span_prim_view *out);
+
+struct yetty_ypaint_prim_base_ops_ptr_result
+yetty_ypaint_text_span_prim_handler(uint32_t prim_type);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* YETTY_YPAINT_CORE_TEXT_SPAN_PRIM_H */

--- a/src/yetty/ypaint-core/CMakeLists.txt
+++ b/src/yetty/ypaint-core/CMakeLists.txt
@@ -2,6 +2,8 @@ add_library(yetty_ypaint_core STATIC
     buffer.c
     complex-prim-types.c
     flyweight.c
+    font-prim.c
+    text-span-prim.c
 )
 
 target_include_directories(yetty_ypaint_core PUBLIC

--- a/src/yetty/ypaint-core/buffer.c
+++ b/src/yetty/ypaint-core/buffer.c
@@ -1,24 +1,26 @@
 // YPaint Buffer - Implementation
+//
+// The buffer is a single byte stream of primitives. Everything — SDF shapes,
+// fonts, text spans, complex prims — is a primitive identified by the type
+// word at the start of each entry. Iteration is type-agnostic via the
+// flyweight registry (size + aabb come from per-type base ops).
+//
+// add_font / add_text exist as convenience wrappers that pack the
+// flyweight wire layout (font-prim.c / text-span-prim.c) and call
+// add_prim — same path SDF emitters take.
 
 #include <stdlib.h>
 #include <string.h>
 #include <yetty/ypaint-core/buffer.h>
+#include <yetty/ypaint-core/font-prim.h>
+#include <yetty/ypaint-core/text-span-prim.h>
 #include <yetty/ycore/util.h>
 #include <yetty/ytrace.h>
 
 #define YPAINT_BUFFER_INITIAL_CAPACITY 1024
-#define YPAINT_MAX_FONTS 8
-#define YPAINT_MAX_TEXT_SPANS 4096
 
-// YPaint buffer - contains primitive data, fonts, text spans
 struct yetty_ypaint_core_buffer {
   struct yetty_ycore_named_buffer primitives;
-
-  struct yetty_font_blob fonts[YPAINT_MAX_FONTS];
-  uint32_t font_count;
-
-  struct yetty_text_span text_spans[YPAINT_MAX_TEXT_SPANS];
-  uint32_t text_span_count;
 
   float scene_min_x, scene_min_y, scene_max_x, scene_max_y;
 
@@ -29,80 +31,43 @@ struct yetty_ypaint_core_buffer {
 
 /* Framed wire format. Magic chosen so it can't look like a valid
  * ysdf primitive header (primitive types are < 256, scene bounds start
- * with a float). */
+ * with a float). Layout:
+ *   u32 magic
+ *   f32 scene_min_x, scene_min_y, scene_max_x, scene_max_y
+ *   u32 byte_count
+ *   u8  prim_bytes[byte_count]
+ */
 #define YPAINT_SERIAL_MAGIC 0x31425059u  /* 'YPB1' little-endian */
-
-/* Read helpers — advance *p if enough bytes remain, else bail. */
-static int _read_u32(const uint8_t **p, const uint8_t *end, uint32_t *out) {
-  if ((size_t)(end - *p) < 4) return 0;
-  memcpy(out, *p, 4); *p += 4; return 1;
-}
-static int _read_i32(const uint8_t **p, const uint8_t *end, int32_t *out) {
-  if ((size_t)(end - *p) < 4) return 0;
-  memcpy(out, *p, 4); *p += 4; return 1;
-}
-static int _read_f32(const uint8_t **p, const uint8_t *end, float *out) {
-  if ((size_t)(end - *p) < 4) return 0;
-  memcpy(out, *p, 4); *p += 4; return 1;
-}
+#define YPAINT_SERIAL_HEADER_BYTES (4 + 16 + 4)
 
 static int parse_framed_payload(struct yetty_ypaint_core_buffer *buf,
                                 const uint8_t *data, size_t size) {
-  const uint8_t *p = data;
-  const uint8_t *end = data + size;
+  if (size < YPAINT_SERIAL_HEADER_BYTES)
+    return 0;
 
-  /* magic already validated by caller; skip past it. */
+  const uint8_t *p = data + 4; /* skip magic, validated by caller */
+  memcpy(&buf->scene_min_x, p,  4);
+  memcpy(&buf->scene_min_y, p + 4,  4);
+  memcpy(&buf->scene_max_x, p + 8,  4);
+  memcpy(&buf->scene_max_y, p + 12, 4);
+  p += 16;
+
+  uint32_t byte_count;
+  memcpy(&byte_count, p, 4);
   p += 4;
 
-  if (!_read_f32(&p, end, &buf->scene_min_x)) return 0;
-  if (!_read_f32(&p, end, &buf->scene_min_y)) return 0;
-  if (!_read_f32(&p, end, &buf->scene_max_x)) return 0;
-  if (!_read_f32(&p, end, &buf->scene_max_y)) return 0;
+  if (byte_count > size - YPAINT_SERIAL_HEADER_BYTES)
+    return 0;
 
-  uint32_t prim_size;
-  if (!_read_u32(&p, end, &prim_size)) return 0;
-  if ((size_t)(end - p) < prim_size) return 0;
-  if (prim_size > 0) {
-    uint8_t *pd = malloc(prim_size);
+  if (byte_count > 0) {
+    uint8_t *pd = malloc(byte_count);
     if (!pd) return 0;
-    memcpy(pd, p, prim_size);
+    memcpy(pd, p, byte_count);
     free(buf->primitives.buf.data);
     buf->primitives.buf.data = pd;
-    buf->primitives.buf.size = prim_size;
-    buf->primitives.buf.capacity = prim_size;
+    buf->primitives.buf.size = byte_count;
+    buf->primitives.buf.capacity = byte_count;
   }
-  p += prim_size;
-
-  uint32_t text_count;
-  if (!_read_u32(&p, end, &text_count)) return 0;
-  if (text_count > YPAINT_MAX_TEXT_SPANS) text_count = YPAINT_MAX_TEXT_SPANS;
-  for (uint32_t i = 0; i < text_count; i++) {
-    struct yetty_text_span *ts = &buf->text_spans[i];
-    if (!_read_f32(&p, end, &ts->x)) return 0;
-    if (!_read_f32(&p, end, &ts->y)) return 0;
-    if (!_read_f32(&p, end, &ts->font_size)) return 0;
-    if (!_read_f32(&p, end, &ts->rotation)) return 0;
-    uint32_t color;
-    if (!_read_u32(&p, end, &color)) return 0;
-    ts->color.r = color & 0xFF;
-    ts->color.g = (color >> 8) & 0xFF;
-    ts->color.b = (color >> 16) & 0xFF;
-    ts->color.a = (color >> 24) & 0xFF;
-    if (!_read_u32(&p, end, &ts->layer)) return 0;
-    if (!_read_i32(&p, end, &ts->font_id)) return 0;
-    uint32_t tl;
-    if (!_read_u32(&p, end, &tl)) return 0;
-    if ((size_t)(end - p) < tl) return 0;
-    if (tl > 0) {
-      ts->named_buf.buf.data = malloc(tl);
-      if (!ts->named_buf.buf.data) return 0;
-      memcpy(ts->named_buf.buf.data, p, tl);
-      ts->named_buf.buf.size = tl;
-      ts->named_buf.buf.capacity = tl;
-    }
-    p += tl;
-  }
-  buf->text_span_count = text_count;
   return 1;
 }
 
@@ -117,24 +82,23 @@ struct yetty_ypaint_core_buffer_result yetty_ypaint_core_buffer_create_from_byte
   if (!buf)
     return YETTY_ERR(yetty_ypaint_core_buffer, "calloc failed");
 
-  uint8_t *decoded = malloc(len);
-  if (!decoded) {
-    free(buf);
-    return YETTY_ERR(yetty_ypaint_core_buffer, "malloc failed");
-  }
-  memcpy(decoded, data, len);
-
-  /* Framed (magic-tagged) payload = prims + text_spans + scene_bounds.
+  /* Framed (magic-tagged) payload = scene_bounds + raw prim stream.
    * Otherwise the bytes are a bare primitive stream (legacy path). */
-  if (len >= 4 && *(uint32_t *)decoded == YPAINT_SERIAL_MAGIC) {
-    if (!parse_framed_payload(buf, decoded, len)) {
-      free(decoded);
+  uint32_t magic;
+  memcpy(&magic, data, len >= 4 ? 4 : 0);
+  if (len >= 4 && magic == YPAINT_SERIAL_MAGIC) {
+    if (!parse_framed_payload(buf, data, len)) {
       yetty_ypaint_core_buffer_destroy(buf);
       return YETTY_ERR(yetty_ypaint_core_buffer, "framed payload parse failed");
     }
-    free(decoded);
   } else {
-    buf->primitives.buf.data = decoded;
+    uint8_t *copy = malloc(len);
+    if (!copy) {
+      free(buf);
+      return YETTY_ERR(yetty_ypaint_core_buffer, "malloc failed");
+    }
+    memcpy(copy, data, len);
+    buf->primitives.buf.data = copy;
     buf->primitives.buf.capacity = len;
     buf->primitives.buf.size = len;
   }
@@ -209,11 +173,6 @@ void yetty_ypaint_core_buffer_destroy(struct yetty_ypaint_core_buffer *buf) {
 
   free(buf->primitives.buf.data);
   free(buf->serial_data);
-
-  /* Free text span data (text_spans is embedded array, only free inner data) */
-  for (uint32_t i = 0; i < buf->text_span_count; i++)
-    free(buf->text_spans[i].named_buf.buf.data);
-
   free(buf);
 }
 
@@ -223,13 +182,6 @@ void yetty_ypaint_core_buffer_clear(struct yetty_ypaint_core_buffer *buf) {
     return;
   }
   buf->primitives.buf.size = 0;
-  /* Free any text-span data allocated between clears, then reset count. */
-  for (uint32_t i = 0; i < buf->text_span_count; i++) {
-    free(buf->text_spans[i].named_buf.buf.data);
-    buf->text_spans[i].named_buf.buf.data = NULL;
-    buf->text_spans[i].named_buf.buf.size = 0;
-  }
-  buf->text_span_count = 0;
 }
 
 const void *yetty_ypaint_core_buffer_data(const struct yetty_ypaint_core_buffer *buf) {
@@ -251,117 +203,6 @@ void yetty_ypaint_core_buffer_set_scene_bounds(struct yetty_ypaint_core_buffer *
   buf->scene_max_y = max_y;
 }
 
-/* Shared emitter for the framed wire format. Both _serialize (writes raw
- * bytes into the reusable scratch) and _to_base64 (streams base64 chars
- * directly into a caller-sized output, no intermediate blob) feed their
- * sinks through this. Mirror of parse_framed_payload — layouts must stay
- * in sync. */
-typedef void (*ypaint_emit_fn)(const void *data, size_t size, void *ctx);
-
-static size_t ypaint_framed_size(const struct yetty_ypaint_core_buffer *buf) {
-  size_t need = 4 + 16 + 4 + buf->primitives.buf.size + 4;
-  for (uint32_t i = 0; i < buf->text_span_count; i++) {
-    /* x,y,font_size,rotation,color,layer,font_id,text_len + payload */
-    need += 4 * 7 + 4 + buf->text_spans[i].named_buf.buf.size;
-  }
-  return need;
-}
-
-static void ypaint_framed_emit(const struct yetty_ypaint_core_buffer *buf,
-                                ypaint_emit_fn emit, void *ctx) {
-  uint32_t u;
-  u = YPAINT_SERIAL_MAGIC;           emit(&u, 4, ctx);
-  emit(&buf->scene_min_x, 4, ctx);
-  emit(&buf->scene_min_y, 4, ctx);
-  emit(&buf->scene_max_x, 4, ctx);
-  emit(&buf->scene_max_y, 4, ctx);
-  u = (uint32_t)buf->primitives.buf.size;
-  emit(&u, 4, ctx);
-  if (buf->primitives.buf.size > 0)
-    emit(buf->primitives.buf.data, buf->primitives.buf.size, ctx);
-  u = buf->text_span_count;
-  emit(&u, 4, ctx);
-  for (uint32_t i = 0; i < buf->text_span_count; i++) {
-    const struct yetty_text_span *ts = &buf->text_spans[i];
-    emit(&ts->x, 4, ctx);
-    emit(&ts->y, 4, ctx);
-    emit(&ts->font_size, 4, ctx);
-    emit(&ts->rotation, 4, ctx);
-    uint32_t color = (uint32_t)ts->color.r
-                   | ((uint32_t)ts->color.g << 8)
-                   | ((uint32_t)ts->color.b << 16)
-                   | ((uint32_t)ts->color.a << 24);
-    emit(&color, 4, ctx);
-    emit(&ts->layer, 4, ctx);
-    emit(&ts->font_id, 4, ctx);
-    uint32_t tl = (uint32_t)ts->named_buf.buf.size;
-    emit(&tl, 4, ctx);
-    if (tl > 0)
-      emit(ts->named_buf.buf.data, tl, ctx);
-  }
-}
-
-/* Sink 1: raw bytes, advancing a write cursor. */
-struct ypaint_raw_sink { uint8_t *p; };
-static void ypaint_raw_emit(const void *data, size_t size, void *ctx) {
-  struct ypaint_raw_sink *s = ctx;
-  memcpy(s->p, data, size);
-  s->p += size;
-}
-
-/* Sink 2: streaming base64 — 3-byte rolling window, 4 chars at a time. */
-static const char YPAINT_B64_ALPHABET[] =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
-struct ypaint_b64_sink {
-  char   *out;
-  size_t  olen;
-  uint8_t window[3];
-  int     wc;        /* 0..3 bytes currently buffered in `window` */
-};
-
-static inline void ypaint_b64_flush_triple(struct ypaint_b64_sink *s) {
-  uint32_t t = ((uint32_t)s->window[0] << 16)
-             | ((uint32_t)s->window[1] <<  8)
-             |  (uint32_t)s->window[2];
-  s->out[s->olen++] = YPAINT_B64_ALPHABET[(t >> 18) & 0x3F];
-  s->out[s->olen++] = YPAINT_B64_ALPHABET[(t >> 12) & 0x3F];
-  s->out[s->olen++] = YPAINT_B64_ALPHABET[(t >>  6) & 0x3F];
-  s->out[s->olen++] = YPAINT_B64_ALPHABET[ t        & 0x3F];
-  s->wc = 0;
-}
-
-static void ypaint_b64_emit(const void *data, size_t size, void *ctx) {
-  struct ypaint_b64_sink *s = ctx;
-  const uint8_t *p = data;
-  while (size > 0) {
-    while (s->wc < 3 && size > 0) {
-      s->window[s->wc++] = *p++;
-      size--;
-    }
-    if (s->wc == 3)
-      ypaint_b64_flush_triple(s);
-  }
-}
-
-static void ypaint_b64_finalize(struct ypaint_b64_sink *s) {
-  if (s->wc == 1) {
-    uint32_t t = (uint32_t)s->window[0] << 16;
-    s->out[s->olen++] = YPAINT_B64_ALPHABET[(t >> 18) & 0x3F];
-    s->out[s->olen++] = YPAINT_B64_ALPHABET[(t >> 12) & 0x3F];
-    s->out[s->olen++] = '=';
-    s->out[s->olen++] = '=';
-  } else if (s->wc == 2) {
-    uint32_t t = ((uint32_t)s->window[0] << 16)
-               | ((uint32_t)s->window[1] <<  8);
-    s->out[s->olen++] = YPAINT_B64_ALPHABET[(t >> 18) & 0x3F];
-    s->out[s->olen++] = YPAINT_B64_ALPHABET[(t >> 12) & 0x3F];
-    s->out[s->olen++] = YPAINT_B64_ALPHABET[(t >>  6) & 0x3F];
-    s->out[s->olen++] = '=';
-  }
-  s->out[s->olen] = '\0';
-}
-
 size_t yetty_ypaint_core_buffer_serialize(
     struct yetty_ypaint_core_buffer *buf, const uint8_t **out_data) {
   if (!buf || !out_data) {
@@ -369,7 +210,7 @@ size_t yetty_ypaint_core_buffer_serialize(
     return 0;
   }
 
-  size_t need = ypaint_framed_size(buf);
+  size_t need = YPAINT_SERIAL_HEADER_BYTES + buf->primitives.buf.size;
 
   if (buf->serial_cap < need) {
     uint8_t *np = realloc(buf->serial_data, need);
@@ -381,34 +222,89 @@ size_t yetty_ypaint_core_buffer_serialize(
     buf->serial_cap = need;
   }
 
-  struct ypaint_raw_sink sink = { .p = buf->serial_data };
-  ypaint_framed_emit(buf, ypaint_raw_emit, &sink);
+  uint8_t *p = buf->serial_data;
+  uint32_t magic = YPAINT_SERIAL_MAGIC;
+  memcpy(p, &magic, 4); p += 4;
+  memcpy(p, &buf->scene_min_x, 4); p += 4;
+  memcpy(p, &buf->scene_min_y, 4); p += 4;
+  memcpy(p, &buf->scene_max_x, 4); p += 4;
+  memcpy(p, &buf->scene_max_y, 4); p += 4;
+  uint32_t byte_count = (uint32_t)buf->primitives.buf.size;
+  memcpy(p, &byte_count, 4); p += 4;
+  if (byte_count > 0)
+    memcpy(p, buf->primitives.buf.data, byte_count);
 
   *out_data = buf->serial_data;
   return need;
 }
 
-/* Single-pass, single-allocation base64 of the framed wire format. Writes
- * base64 chars directly into the output as the framed fields are produced
- * — no intermediate raw blob, no double copy. */
+/* Single-pass base64 encode of the framed wire format. */
+static const char YPAINT_B64_ALPHABET[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
 struct yetty_ycore_buffer_result yetty_ypaint_core_buffer_to_base64(
     const struct yetty_ypaint_core_buffer *buf) {
   if (!buf)
     return YETTY_ERR(yetty_ycore_buffer, "buf is NULL");
 
-  size_t need = ypaint_framed_size(buf);
-  size_t cap = ((need + 2) / 3) * 4 + 1;  /* base64 len + NUL */
+  size_t need = YPAINT_SERIAL_HEADER_BYTES + buf->primitives.buf.size;
+  size_t cap = ((need + 2) / 3) * 4 + 1;
   char *out = malloc(cap);
   if (!out)
     return YETTY_ERR(yetty_ycore_buffer, "malloc failed");
 
-  struct ypaint_b64_sink sink = { .out = out, .olen = 0, .wc = 0 };
-  ypaint_framed_emit(buf, ypaint_b64_emit, &sink);
-  ypaint_b64_finalize(&sink);
+  /* Build the framed bytes into a temporary stack-friendly path: write
+   * directly into a small buffer and then base64. For very small
+   * payloads avoiding malloc here would be nice, but serialize() does
+   * the same allocation pattern via serial_data. Just allocate once. */
+  uint8_t *raw = malloc(need);
+  if (!raw) {
+    free(out);
+    return YETTY_ERR(yetty_ycore_buffer, "malloc failed");
+  }
+
+  uint8_t *p = raw;
+  uint32_t magic = YPAINT_SERIAL_MAGIC;
+  memcpy(p, &magic, 4); p += 4;
+  memcpy(p, &buf->scene_min_x, 4); p += 4;
+  memcpy(p, &buf->scene_min_y, 4); p += 4;
+  memcpy(p, &buf->scene_max_x, 4); p += 4;
+  memcpy(p, &buf->scene_max_y, 4); p += 4;
+  uint32_t byte_count = (uint32_t)buf->primitives.buf.size;
+  memcpy(p, &byte_count, 4); p += 4;
+  if (byte_count > 0)
+    memcpy(p, buf->primitives.buf.data, byte_count);
+
+  size_t olen = 0;
+  for (size_t i = 0; i + 3 <= need; i += 3) {
+    uint32_t t = ((uint32_t)raw[i] << 16) | ((uint32_t)raw[i+1] << 8)
+               |  (uint32_t)raw[i+2];
+    out[olen++] = YPAINT_B64_ALPHABET[(t >> 18) & 0x3F];
+    out[olen++] = YPAINT_B64_ALPHABET[(t >> 12) & 0x3F];
+    out[olen++] = YPAINT_B64_ALPHABET[(t >>  6) & 0x3F];
+    out[olen++] = YPAINT_B64_ALPHABET[ t        & 0x3F];
+  }
+  size_t rem = need % 3;
+  if (rem == 1) {
+    uint32_t t = (uint32_t)raw[need - 1] << 16;
+    out[olen++] = YPAINT_B64_ALPHABET[(t >> 18) & 0x3F];
+    out[olen++] = YPAINT_B64_ALPHABET[(t >> 12) & 0x3F];
+    out[olen++] = '=';
+    out[olen++] = '=';
+  } else if (rem == 2) {
+    uint32_t t = ((uint32_t)raw[need - 2] << 16)
+               | ((uint32_t)raw[need - 1] <<  8);
+    out[olen++] = YPAINT_B64_ALPHABET[(t >> 18) & 0x3F];
+    out[olen++] = YPAINT_B64_ALPHABET[(t >> 12) & 0x3F];
+    out[olen++] = YPAINT_B64_ALPHABET[(t >>  6) & 0x3F];
+    out[olen++] = '=';
+  }
+  out[olen] = '\0';
+  free(raw);
 
   struct yetty_ycore_buffer b = {0};
   b.data = (uint8_t *)out;
-  b.size = sink.olen;
+  b.size = olen;
   b.capacity = cap;
   return YETTY_OK(yetty_ycore_buffer, b);
 }
@@ -517,7 +413,8 @@ struct yetty_ypaint_core_primitive_iter_result yetty_ypaint_core_buffer_prim_nex
 }
 
 /*=============================================================================
- * Font blob storage
+ * Producer convenience: pack flyweight FONT / TEXT_SPAN prims into the stream.
+ * Same path as add_prim — these just pack the FAM payload first.
  *===========================================================================*/
 
 struct yetty_ycore_int_result
@@ -529,47 +426,52 @@ yetty_ypaint_core_buffer_add_font(struct yetty_ypaint_core_buffer *buf,
     return YETTY_ERR(yetty_ycore_int, "buf is NULL");
   if (!ttf_data || !ttf_data->data || ttf_data->size == 0)
     return YETTY_ERR(yetty_ycore_int, "ttf_data is empty");
-  if (buf->font_count >= YPAINT_MAX_FONTS)
-    return YETTY_ERR(yetty_ycore_int, "max fonts reached");
 
-  struct yetty_font_blob *fb = &buf->fonts[buf->font_count];
-  fb->font_id = (int32_t)buf->font_count;
+  uint32_t name_len = name ? (uint32_t)strlen(name) : 0;
+  uint32_t ttf_len = (uint32_t)ttf_data->size;
+  size_t prim_size = yetty_ypaint_font_prim_size_for(name_len, ttf_len);
 
-  /* Copy TTF data */
-  fb->named_buf.buf.data = malloc(ttf_data->size);
-  if (!fb->named_buf.buf.data)
-    return YETTY_ERR(yetty_ycore_int, "allocation failed");
-  memcpy(fb->named_buf.buf.data, ttf_data->data, ttf_data->size);
-  fb->named_buf.buf.size = ttf_data->size;
-  fb->named_buf.buf.capacity = ttf_data->size;
+  uint8_t *staging = malloc(prim_size);
+  if (!staging)
+    return YETTY_ERR(yetty_ycore_int, "alloc failed");
 
-  if (name) {
-    strncpy(fb->named_buf.name, name,
-            YETTY_YCORE_NAMED_BUFFER_MAX_NAME_LENGTH - 1);
+  /* font_id is producer-assigned; we use the byte-offset-based primitive
+   * count would-be, but the canonical id is just the next consecutive one
+   * — producers have always referenced fonts by 0,1,2,… so we keep that.
+   * The receiver builds its own (buf_font_id → MSDF font*) map. */
+  /* Walk existing prims to count fonts so far. Simple, infrequent. */
+  int next_id = 0;
+  const uint8_t *p = buf->primitives.buf.data;
+  const uint8_t *end = p + buf->primitives.buf.size;
+  while (p + 8 <= end) {
+    uint32_t t, ps;
+    memcpy(&t, p, 4);
+    memcpy(&ps, p + 4, 4);
+    if (t == YETTY_YPAINT_TYPE_FONT)
+      next_id++;
+    /* Walk by FAM size for flyweight/complex; otherwise stop — we'd need
+     * the registry to walk SDF prims correctly. We only need to count
+     * FONTs that precede this insertion, and producers add fonts before
+     * other prims in practice (PDF, markdown). If a producer interleaves,
+     * they should pass an explicit id (future API). */
+    if (t >= 0x40000000u) {
+      p += 8 + ps;
+    } else {
+      break;
+    }
   }
 
-  int id = (int)buf->font_count;
-  buf->font_count++;
-  return YETTY_OK(yetty_ycore_int, id);
-}
+  yetty_ypaint_font_prim_write(staging, (int32_t)next_id,
+                               name, name_len,
+                               ttf_data->data, ttf_len);
 
-uint32_t yetty_ypaint_core_buffer_font_count(
-    const struct yetty_ypaint_core_buffer *buf)
-{
-  return buf ? buf->font_count : 0;
+  struct yetty_ypaint_id_result r =
+      yetty_ypaint_core_buffer_add_prim(buf, staging, prim_size);
+  free(staging);
+  if (r.error)
+    return YETTY_ERR(yetty_ycore_int, "add_prim failed");
+  return YETTY_OK(yetty_ycore_int, next_id);
 }
-
-const struct yetty_font_blob *yetty_ypaint_core_buffer_get_font(
-    const struct yetty_ypaint_core_buffer *buf, uint32_t index)
-{
-  if (!buf || index >= buf->font_count)
-    return NULL;
-  return &buf->fonts[index];
-}
-
-/*=============================================================================
- * Text span storage
- *===========================================================================*/
 
 struct yetty_ycore_void_result
 yetty_ypaint_core_buffer_add_text(struct yetty_ypaint_core_buffer *buf,
@@ -583,43 +485,22 @@ yetty_ypaint_core_buffer_add_text(struct yetty_ypaint_core_buffer *buf,
     return YETTY_ERR(yetty_ycore_void, "buf is NULL");
   if (!text || !text->data || text->size == 0)
     return YETTY_ERR(yetty_ycore_void, "text is empty");
-  if (buf->text_span_count >= YPAINT_MAX_TEXT_SPANS)
-    return YETTY_ERR(yetty_ycore_void, "max text spans reached");
 
-  struct yetty_text_span *ts = &buf->text_spans[buf->text_span_count];
-  ts->x = x;
-  ts->y = y;
-  ts->font_size = font_size;
-  ts->color.r = (uint8_t)(color & 0xFF);
-  ts->color.g = (uint8_t)((color >> 8) & 0xFF);
-  ts->color.b = (uint8_t)((color >> 16) & 0xFF);
-  ts->color.a = (uint8_t)((color >> 24) & 0xFF);
-  ts->layer = layer;
-  ts->font_id = font_id;
-  ts->rotation = rotation;
+  uint32_t text_len = (uint32_t)text->size;
+  size_t prim_size = yetty_ypaint_text_span_prim_size_for(text_len);
 
-  /* Copy text data */
-  ts->named_buf.buf.data = malloc(text->size);
-  if (!ts->named_buf.buf.data)
-    return YETTY_ERR(yetty_ycore_void, "allocation failed");
-  memcpy(ts->named_buf.buf.data, text->data, text->size);
-  ts->named_buf.buf.size = text->size;
-  ts->named_buf.buf.capacity = text->size;
+  uint8_t *staging = malloc(prim_size);
+  if (!staging)
+    return YETTY_ERR(yetty_ycore_void, "alloc failed");
 
-  buf->text_span_count++;
+  yetty_ypaint_text_span_prim_write(staging, x, y, font_size, rotation,
+                                    color, layer, font_id,
+                                    (const char *)text->data, text_len);
+
+  struct yetty_ypaint_id_result r =
+      yetty_ypaint_core_buffer_add_prim(buf, staging, prim_size);
+  free(staging);
+  if (r.error)
+    return YETTY_ERR(yetty_ycore_void, "add_prim failed");
   return YETTY_OK_VOID();
-}
-
-uint32_t yetty_ypaint_core_buffer_text_span_count(
-    const struct yetty_ypaint_core_buffer *buf)
-{
-  return buf ? buf->text_span_count : 0;
-}
-
-const struct yetty_text_span *yetty_ypaint_core_buffer_get_text_span(
-    const struct yetty_ypaint_core_buffer *buf, uint32_t index)
-{
-  if (!buf || index >= buf->text_span_count)
-    return NULL;
-  return &buf->text_spans[index];
 }

--- a/src/yetty/ypaint-core/font-prim.c
+++ b/src/yetty/ypaint-core/font-prim.c
@@ -1,0 +1,119 @@
+/*
+ * font-prim.c - flyweight FONT primitive (see font-prim.h).
+ */
+
+#include <yetty/ypaint-core/font-prim.h>
+
+#include <string.h>
+
+/* FAM header size: type(u32) + payload_size(u32). */
+#define FONT_PRIM_HEADER 8u
+
+/* Round up to a multiple of 4 so the next prim in the stream is aligned. */
+static inline uint32_t align4(uint32_t n)
+{
+	return (n + 3u) & ~3u;
+}
+
+static uint32_t font_payload_size(uint32_t name_len, uint32_t ttf_len)
+{
+	/* font_id(4) + name_len(4) + name + ttf_len(4) + ttf */
+	uint32_t bare = 4u + 4u + name_len + 4u + ttf_len;
+	return align4(bare);
+}
+
+size_t yetty_ypaint_font_prim_size_for(uint32_t name_len, uint32_t ttf_len)
+{
+	return FONT_PRIM_HEADER + font_payload_size(name_len, ttf_len);
+}
+
+void yetty_ypaint_font_prim_write(uint8_t *out,
+                                  int32_t font_id,
+                                  const char *name, uint32_t name_len,
+                                  const uint8_t *ttf, uint32_t ttf_len)
+{
+	uint32_t payload_size = font_payload_size(name_len, ttf_len);
+	size_t total = FONT_PRIM_HEADER + payload_size;
+
+	/* Zero pad slot first so trailing alignment bytes are deterministic. */
+	memset(out, 0, total);
+
+	uint32_t type = YETTY_YPAINT_TYPE_FONT;
+	memcpy(out + 0, &type, 4);
+	memcpy(out + 4, &payload_size, 4);
+
+	uint8_t *p = out + FONT_PRIM_HEADER;
+	memcpy(p, &font_id, 4);              p += 4;
+	memcpy(p, &name_len, 4);             p += 4;
+	if (name_len) {
+		memcpy(p, name, name_len);   p += name_len;
+	}
+	memcpy(p, &ttf_len, 4);              p += 4;
+	if (ttf_len)
+		memcpy(p, ttf, ttf_len);
+}
+
+int yetty_ypaint_font_prim_parse(const uint32_t *prim,
+                                 struct yetty_ypaint_font_prim_view *out)
+{
+	if (!prim || !out)
+		return -1;
+
+	uint32_t type, payload_size;
+	memcpy(&type, prim, 4);
+	memcpy(&payload_size, (const uint8_t *)prim + 4, 4);
+	if (type != YETTY_YPAINT_TYPE_FONT)
+		return -1;
+	if (payload_size < 12) /* font_id + name_len + ttf_len at minimum */
+		return -1;
+
+	const uint8_t *p = (const uint8_t *)prim + FONT_PRIM_HEADER;
+	const uint8_t *end = p + payload_size;
+
+	memcpy(&out->font_id, p, 4); p += 4;
+	memcpy(&out->name_len, p, 4); p += 4;
+	if ((size_t)(end - p) < out->name_len) return -1;
+	out->name = (const char *)p; p += out->name_len;
+	if ((size_t)(end - p) < 4) return -1;
+	memcpy(&out->ttf_len, p, 4); p += 4;
+	if ((size_t)(end - p) < out->ttf_len) return -1;
+	out->ttf = p;
+	return 0;
+}
+
+/*=============================================================================
+ * Flyweight base ops
+ *===========================================================================*/
+
+static struct yetty_ycore_size_result
+font_prim_size(const uint32_t *prim)
+{
+	uint32_t payload_size;
+	memcpy(&payload_size, (const uint8_t *)prim + 4, 4);
+	return YETTY_OK(yetty_ycore_size,
+	                FONT_PRIM_HEADER + (size_t)payload_size);
+}
+
+/* Fonts don't render directly — return a degenerate empty rect so the
+ * spatial grid never picks them up. */
+static struct rectangle_result
+font_prim_aabb(const uint32_t *prim)
+{
+	(void)prim;
+	struct rectangle r = { .min = {0, 0}, .max = {0, 0} };
+	return YETTY_OK(rectangle, r);
+}
+
+static const struct yetty_ypaint_prim_base_ops g_font_prim_base_ops = {
+	.size = font_prim_size,
+	.aabb = font_prim_aabb,
+};
+
+struct yetty_ypaint_prim_base_ops_ptr_result
+yetty_ypaint_font_prim_handler(uint32_t prim_type)
+{
+	if (prim_type == YETTY_YPAINT_TYPE_FONT)
+		return YETTY_OK(yetty_ypaint_prim_base_ops_ptr,
+		                &g_font_prim_base_ops);
+	return YETTY_ERR(yetty_ypaint_prim_base_ops_ptr, "not FONT");
+}

--- a/src/yetty/ypaint-core/text-span-prim.c
+++ b/src/yetty/ypaint-core/text-span-prim.c
@@ -1,0 +1,135 @@
+/*
+ * text-span-prim.c - flyweight TEXT_SPAN primitive (see text-span-prim.h).
+ */
+
+#include <yetty/ypaint-core/text-span-prim.h>
+
+#include <math.h>
+#include <string.h>
+
+#define TEXT_SPAN_PRIM_HEADER  8u
+/* Fixed payload prefix: x,y,font_size,rotation,color,layer,font_id,text_len. */
+#define TEXT_SPAN_FIXED_BYTES  32u
+
+static inline uint32_t align4(uint32_t n)
+{
+	return (n + 3u) & ~3u;
+}
+
+static uint32_t text_span_payload_size(uint32_t text_len)
+{
+	return align4(TEXT_SPAN_FIXED_BYTES + text_len);
+}
+
+size_t yetty_ypaint_text_span_prim_size_for(uint32_t text_len)
+{
+	return TEXT_SPAN_PRIM_HEADER + text_span_payload_size(text_len);
+}
+
+void yetty_ypaint_text_span_prim_write(uint8_t *out,
+                                       float x, float y,
+                                       float font_size, float rotation,
+                                       uint32_t color, uint32_t layer,
+                                       int32_t font_id,
+                                       const char *text, uint32_t text_len)
+{
+	uint32_t payload_size = text_span_payload_size(text_len);
+	size_t total = TEXT_SPAN_PRIM_HEADER + payload_size;
+	memset(out, 0, total);
+
+	uint32_t type = YETTY_YPAINT_TYPE_TEXT_SPAN;
+	memcpy(out + 0, &type, 4);
+	memcpy(out + 4, &payload_size, 4);
+
+	uint8_t *p = out + TEXT_SPAN_PRIM_HEADER;
+	memcpy(p, &x, 4);          p += 4;
+	memcpy(p, &y, 4);          p += 4;
+	memcpy(p, &font_size, 4);  p += 4;
+	memcpy(p, &rotation, 4);   p += 4;
+	memcpy(p, &color, 4);      p += 4;
+	memcpy(p, &layer, 4);      p += 4;
+	memcpy(p, &font_id, 4);    p += 4;
+	memcpy(p, &text_len, 4);   p += 4;
+	if (text_len)
+		memcpy(p, text, text_len);
+}
+
+int yetty_ypaint_text_span_prim_parse(
+	const uint32_t *prim,
+	struct yetty_ypaint_text_span_prim_view *out)
+{
+	if (!prim || !out)
+		return -1;
+
+	uint32_t type, payload_size;
+	memcpy(&type, prim, 4);
+	memcpy(&payload_size, (const uint8_t *)prim + 4, 4);
+	if (type != YETTY_YPAINT_TYPE_TEXT_SPAN)
+		return -1;
+	if (payload_size < TEXT_SPAN_FIXED_BYTES)
+		return -1;
+
+	const uint8_t *p = (const uint8_t *)prim + TEXT_SPAN_PRIM_HEADER;
+	const uint8_t *end = p + payload_size;
+
+	memcpy(&out->x, p, 4);         p += 4;
+	memcpy(&out->y, p, 4);         p += 4;
+	memcpy(&out->font_size, p, 4); p += 4;
+	memcpy(&out->rotation, p, 4);  p += 4;
+	memcpy(&out->color, p, 4);     p += 4;
+	memcpy(&out->layer, p, 4);     p += 4;
+	memcpy(&out->font_id, p, 4);   p += 4;
+	memcpy(&out->text_len, p, 4);  p += 4;
+	if ((size_t)(end - p) < out->text_len) return -1;
+	out->text = (const char *)p;
+	return 0;
+}
+
+/*=============================================================================
+ * Flyweight base ops
+ *===========================================================================*/
+
+static struct yetty_ycore_size_result
+text_span_prim_size(const uint32_t *prim)
+{
+	uint32_t payload_size;
+	memcpy(&payload_size, (const uint8_t *)prim + 4, 4);
+	return YETTY_OK(yetty_ycore_size,
+	                TEXT_SPAN_PRIM_HEADER + (size_t)payload_size);
+}
+
+/* Coarse AABB — the canvas decomposes a TEXT_SPAN into per-glyph SDF
+ * prims (each with an exact AABB) before any spatial-grid placement,
+ * so this is only used for the PASS-1 max-row computation. Width is
+ * estimated at 0.6 * font_size per UTF-8 byte (over-estimate for
+ * multi-byte sequences but never under-estimates the row span). */
+static struct rectangle_result
+text_span_prim_aabb(const uint32_t *prim)
+{
+	struct yetty_ypaint_text_span_prim_view v;
+	if (yetty_ypaint_text_span_prim_parse(prim, &v) < 0)
+		return YETTY_ERR(rectangle, "malformed TEXT_SPAN");
+
+	float w_est = 0.6f * v.font_size * (float)v.text_len;
+	float h_est = v.font_size;
+	struct rectangle r = {
+		.min = { .x = v.x,         .y = v.y - h_est },
+		.max = { .x = v.x + w_est, .y = v.y         },
+	};
+	(void)fabsf;
+	return YETTY_OK(rectangle, r);
+}
+
+static const struct yetty_ypaint_prim_base_ops g_text_span_prim_base_ops = {
+	.size = text_span_prim_size,
+	.aabb = text_span_prim_aabb,
+};
+
+struct yetty_ypaint_prim_base_ops_ptr_result
+yetty_ypaint_text_span_prim_handler(uint32_t prim_type)
+{
+	if (prim_type == YETTY_YPAINT_TYPE_TEXT_SPAN)
+		return YETTY_OK(yetty_ypaint_prim_base_ops_ptr,
+		                &g_text_span_prim_base_ops);
+	return YETTY_ERR(yetty_ypaint_prim_base_ops_ptr, "not TEXT_SPAN");
+}

--- a/src/yetty/ypaint/CMakeLists.txt
+++ b/src/yetty/ypaint/CMakeLists.txt
@@ -9,4 +9,8 @@ add_library(yetty_ypaint STATIC
 target_link_libraries(yetty_ypaint PUBLIC
     yetty_ypaint_core
     yetty_ysdf
+    yetty_ymsdf_gen
 )
+# Note: yetty_ypaint references yplatform_mkdir_p / yplatform_file_exists
+# (per-platform shared sources). Final executables already include
+# YETTY_YPLATFORM_THREAD_SOURCES, so these symbols resolve at link time.

--- a/src/yetty/ypaint/flyweight.c
+++ b/src/yetty/ypaint/flyweight.c
@@ -1,14 +1,18 @@
-// YPaint Flyweight - creates configured flyweight registry for ALL primitives
+// YPaint Flyweight - creates configured flyweight registry for ALL primitives.
 //
-// Two handlers:
-// 1. SDF handler (default) - for types 0-255
-// 2. Complex prim handler - for types >= 0x80000000
+// Three tiers, see complex-prim-types.h for the type-id ranges:
+//   1. SDF default handler                   types [0x00, 0xFF]
+//   2. FONT      flyweight handler           type   0x40000001
+//   3. TEXT_SPAN flyweight handler           type   0x40000002
+//   4. Complex prim handler (factory-based)  types [0x80000000, 0xFFFFFFFF]
 //
-// Both return base ops (size, aabb) for buffer iteration.
+// All return base ops (size, aabb) for buffer iteration.
 
 #include <yetty/ypaint/flyweight.h>
 #include <yetty/ysdf/handler.h>
 #include <yetty/ypaint-core/complex-prim-types.h>
+#include <yetty/ypaint-core/font-prim.h>
+#include <yetty/ypaint-core/text-span-prim.h>
 #include <yetty/ytrace.h>
 
 struct yetty_ypaint_flyweight_registry_ptr_result
@@ -23,13 +27,20 @@ yetty_ypaint_flyweight_create(void)
 
     // Default handler for SDF primitives (fast path, types 0-255)
     yetty_ypaint_flyweight_registry_set_default(reg, yetty_ysdf_handler);
-    ydebug("flyweight_create: registered SDF default handler");
+
+    // Flyweight prims — one handler per type id, registered like SDF/complex
+    yetty_ypaint_flyweight_registry_add(reg,
+        YETTY_YPAINT_TYPE_FONT, YETTY_YPAINT_TYPE_FONT,
+        yetty_ypaint_font_prim_handler);
+    yetty_ypaint_flyweight_registry_add(reg,
+        YETTY_YPAINT_TYPE_TEXT_SPAN, YETTY_YPAINT_TYPE_TEXT_SPAN,
+        yetty_ypaint_text_span_prim_handler);
 
     // Complex prim handler (types >= 0x80000000)
     yetty_ypaint_flyweight_registry_add(reg,
         YETTY_YPAINT_COMPLEX_TYPE_BASE, 0xFFFFFFFF,
         yetty_ypaint_complex_prim_handler);
-    ydebug("flyweight_create: registered complex prim handler");
 
+    ydebug("flyweight_create: SDF default + FONT + TEXT_SPAN + complex");
     return res;
 }

--- a/src/yetty/ypaint/ypaint-canvas.c
+++ b/src/yetty/ypaint/ypaint-canvas.c
@@ -6,20 +6,28 @@
 #include <stdlib.h>
 #include <string.h>
 #include <yetty/yplatform/compat.h>
+#include <yetty/yplatform/fs.h>
 #include <yetty/ycore/result.h>
 #include <yetty/ycore/types.h>
 #include <yetty/ypaint-core/buffer.h>
 #include <yetty/ypaint-core/complex-prim-types.h>
+#include <yetty/ypaint-core/font-prim.h>
+#include <yetty/ypaint-core/text-span-prim.h>
 #include <yetty/ypaint/flyweight.h>
 #include <yetty/ypaint/core/ypaint-canvas.h>
 #include <yetty/yfont/font.h>
 #include <yetty/yfont/msdf-font.h>
 #include <yetty/yfont/raster-font.h>
+#include <yetty/ymsdf-gen/ymsdf-gen.h>
 #include <yetty/ysdf/types.gen.h>
 #include <yetty/yconfig.h>
 #include <yetty/yetty.h>
 #include <yetty/yplot/yplot-gen.h>
 #include <yetty/ytrace.h>
+
+/* Provided per-platform (yplatform/{linux,macos,windows,android,ios,webasm}/
+ * platform-paths.{c,m}). Returns a writable directory unique to the user. */
+extern const char *yetty_yplatform_get_cache_dir(void);
 
 /* Glyph primitive type (not in ysdf types.gen.h since not SDF) */
 #define YETTY_YSDF_GLYPH 200
@@ -472,25 +480,92 @@ ypaint_canvas_make_default_font(const struct yetty_ypaint_canvas *canvas) {
   return yetty_font_msdf_font_create(cdb_path, shader_path);
 }
 
-/* Construct a yetty_font_font for a buffer-supplied font blob. The blob's
- * `name` holds the source path; its extension decides which backend to use,
- * falling back to the canvas-configured method. */
-static struct yetty_font_font_result
-ypaint_canvas_make_blob_font(const struct yetty_ypaint_canvas *canvas,
-                             const char *blob_name) {
-  if (!blob_name || !blob_name[0])
-    return YETTY_ERR(yetty_font_font, "font blob name is empty");
+/* FNV-1a 64-bit hash — content-addressing for font cache filenames. */
+static uint64_t fnv1a64(const uint8_t *data, size_t len) {
+  uint64_t h = 14695981039346656037ULL;
+  for (size_t i = 0; i < len; i++) {
+    h ^= data[i];
+    h *= 1099511628211ULL;
+  }
+  return h;
+}
 
-  char shader_path[768];
-  if (blob_is_raster(blob_name, canvas->font_render_method)) {
+/* Materialize a buffer-supplied FONT prim into a yetty_font_font.
+ *
+ * The TTF bytes travel inline in the prim payload — we hash them, write to
+ * a content-addressed file under <cache>/ypaint-fonts/, generate the MSDF
+ * CDB on cache miss via ymsdf-gen, then load the MSDF font. Subsequent
+ * occurrences of the same font (same content hash) reuse the cached CDB. */
+static struct yetty_font_font_result
+ypaint_canvas_materialize_blob_font(const struct yetty_ypaint_canvas *canvas,
+                                    const uint8_t *ttf, uint32_t ttf_len,
+                                    const char *hint_name) {
+  if (!ttf || ttf_len == 0)
+    return YETTY_ERR(yetty_font_font, "TTF blob is empty");
+
+  uint64_t h = fnv1a64(ttf, ttf_len);
+  char hex[17];
+  snprintf(hex, sizeof(hex), "%016llx", (unsigned long long)h);
+
+  const char *cache_dir = yetty_yplatform_get_cache_dir();
+  if (!cache_dir || !*cache_dir)
+    return YETTY_ERR(yetty_font_font, "no cache dir");
+
+  char fonts_dir[768];
+  snprintf(fonts_dir, sizeof(fonts_dir), "%s/ypaint-fonts", cache_dir);
+  yplatform_mkdir_p(fonts_dir);
+
+  char ttf_path[1024], cdb_path[1024], shader_path[1024];
+  snprintf(ttf_path, sizeof(ttf_path), "%s/pdf_%s.ttf", fonts_dir, hex);
+  snprintf(cdb_path, sizeof(cdb_path), "%s/pdf_%s.cdb", fonts_dir, hex);
+
+  /* Raster path: just write the TTF and load it directly — no atlas
+   * pre-generation needed. Used when the canvas is configured for raster
+   * rendering or when the hint name explicitly says so. */
+  if (blob_is_raster(hint_name, canvas->font_render_method)) {
+    if (!yplatform_file_exists(ttf_path)) {
+      FILE *f = fopen(ttf_path, "wb");
+      if (!f)
+        return YETTY_ERR(yetty_font_font, "open ttf cache for write");
+      fwrite(ttf, 1, ttf_len, f);
+      fclose(f);
+    }
     snprintf(shader_path, sizeof(shader_path), "%s/raster-font.wgsl",
              canvas->shaders_dir);
-    return yetty_font_raster_font_create_from_file(blob_name, shader_path,
+    return yetty_font_raster_font_create_from_file(ttf_path, shader_path,
                                                    canvas->raster_base_size);
   }
+
+  /* MSDF path: write the TTF to cache, then generate the CDB on miss. */
+  if (!yplatform_file_exists(ttf_path)) {
+    FILE *f = fopen(ttf_path, "wb");
+    if (!f)
+      return YETTY_ERR(yetty_font_font, "open ttf cache for write");
+    fwrite(ttf, 1, ttf_len, f);
+    fclose(f);
+    ydebug("ypaint_canvas: cached TTF '%s' (%u bytes) hint='%s'",
+           ttf_path, ttf_len, hint_name ? hint_name : "");
+  }
+
+  if (!yplatform_file_exists(cdb_path)) {
+    struct yetty_ymsdf_gen_config gen = {0};
+    gen.ttf_path = ttf_path;
+    gen.output_dir = fonts_dir;
+    gen.font_size = 32.0f;
+    gen.pixel_range = 4.0f;
+    gen.thread_count = 0;
+    gen.all_glyphs = 1; /* PDFs may use any codepoint in the font */
+    struct yetty_ycore_void_result gr = yetty_ymsdf_gen_cpu_generate(&gen);
+    if (YETTY_IS_ERR(gr)) {
+      yerror("ypaint_canvas: msdf-gen failed: %s", gr.error.msg);
+      return YETTY_ERR(yetty_font_font, gr.error.msg);
+    }
+    ydebug("ypaint_canvas: generated CDB '%s'", cdb_path);
+  }
+
   snprintf(shader_path, sizeof(shader_path), "%s/msdf-font.wgsl",
            canvas->shaders_dir);
-  return yetty_font_msdf_font_create(blob_name, shader_path);
+  return yetty_font_msdf_font_create(cdb_path, shader_path);
 }
 
 //=============================================================================
@@ -936,6 +1011,235 @@ struct yetty_ycore_void_result yetty_ypaint_canvas_commit_buffer_internal(
 // Buffer management (public API)
 //=============================================================================
 
+/* Local font map populated as FONT prims are encountered during this
+ * add_buffer call. Maps the producer-assigned font_id (text spans
+ * reference fonts by this id) to the materialized yetty_font_font.
+ *
+ * Capacity is grown on demand — text spans typically reference a small
+ * set of font_ids but a single PDF can carry dozens. */
+struct font_map {
+  struct yetty_font_font **fonts;  /* fonts[i] for font_id == i, NULL if absent */
+  uint32_t capacity;
+};
+
+static void font_map_init(struct font_map *m) {
+  m->fonts = NULL;
+  m->capacity = 0;
+}
+
+static void font_map_grow(struct font_map *m, uint32_t want) {
+  if (want <= m->capacity) return;
+  uint32_t new_cap = m->capacity ? m->capacity * 2 : 8;
+  while (new_cap < want) new_cap *= 2;
+  m->fonts = realloc(m->fonts, new_cap * sizeof(struct yetty_font_font *));
+  for (uint32_t i = m->capacity; i < new_cap; i++)
+    m->fonts[i] = NULL;
+  m->capacity = new_cap;
+}
+
+static struct yetty_font_font *font_map_get(const struct font_map *m,
+                                            uint32_t id) {
+  return id < m->capacity ? m->fonts[id] : NULL;
+}
+
+/* Expand a TEXT_SPAN view into per-glyph SDF primitives at the canvas's
+ * current cursor. Returns the highest grid row touched (0 if no glyphs
+ * placed). */
+static uint32_t expand_text_span_to_glyphs(
+    struct yetty_ypaint_canvas *canvas,
+    const struct yetty_ypaint_text_span_prim_view *ts,
+    struct yetty_font_font *font) {
+  static uint32_t glyph_z_order = 0;
+  float base_size = font->ops->get_base_size(font);
+  float scale = (base_size > 0) ? ts->font_size / base_size : 1.0f;
+  float cursor_x = ts->x;
+  uint32_t glyph_max_row = 0;
+
+  const uint8_t *ptr = (const uint8_t *)ts->text;
+  const uint8_t *end = ptr + ts->text_len;
+
+  while (ptr < end) {
+    /* UTF-8 decode */
+    uint32_t cp = 0;
+    if ((*ptr & 0x80) == 0) {
+      cp = *ptr++;
+    } else if ((*ptr & 0xE0) == 0xC0) {
+      cp = (*ptr++ & 0x1F) << 6;
+      if (ptr < end) cp |= (*ptr++ & 0x3F);
+    } else if ((*ptr & 0xF0) == 0xE0) {
+      cp = (*ptr++ & 0x0F) << 12;
+      if (ptr < end) cp |= (*ptr++ & 0x3F) << 6;
+      if (ptr < end) cp |= (*ptr++ & 0x3F);
+    } else if ((*ptr & 0xF8) == 0xF0) {
+      cp = (*ptr++ & 0x07) << 18;
+      if (ptr < end) cp |= (*ptr++ & 0x3F) << 12;
+      if (ptr < end) cp |= (*ptr++ & 0x3F) << 6;
+      if (ptr < end) cp |= (*ptr++ & 0x3F);
+    } else {
+      ptr++;
+      continue;
+    }
+
+    struct uint32_result gi_res = font->ops->get_glyph_index(font, cp);
+    if (YETTY_IS_ERR(gi_res)) {
+      cursor_x += ts->font_size * 0.5f;
+      continue;
+    }
+    uint32_t glyph_index = gi_res.value;
+
+    struct yetty_yrender_gpu_resource_set_result rs_res =
+        font->ops->get_gpu_resource_set(font);
+    if (YETTY_IS_ERR(rs_res))
+      continue;
+    const struct yetty_yrender_gpu_resource_set *rs = rs_res.value;
+    if (rs->buffer_count == 0 || !rs->buffers[0].data)
+      continue;
+
+    /* Per-glyph metadata: 6 floats [size_x, size_y, bearing_x, bearing_y,
+     * advance, _pad]. */
+    const float *meta = (const float *)rs->buffers[0].data;
+    uint32_t meta_count =
+        (uint32_t)(rs->buffers[0].size / (6 * sizeof(float)));
+    if (glyph_index >= meta_count) {
+      cursor_x += ts->font_size * 0.5f;
+      continue;
+    }
+
+    const float *gm = meta + glyph_index * 6;
+    float size_x = gm[0], size_y = gm[1];
+    float bearing_x = gm[2], bearing_y = gm[3];
+    float advance = gm[4];
+
+    if (size_x <= 0.0f || size_y <= 0.0f) {
+      cursor_x += advance * scale;
+      continue;
+    }
+
+    float gx = cursor_x + bearing_x * scale;
+    float gy = ts->y - bearing_y * scale;
+    float gw = size_x * scale;
+    float gh = size_y * scale;
+
+    /* Glyph SDF prim (7 words): type, z_order, x, y, font_size, packed, color */
+    float glyph_data[YPAINT_GLYPH_WORDS];
+    uint32_t tmp;
+    tmp = YETTY_YSDF_GLYPH;
+    memcpy(&glyph_data[0], &tmp, sizeof(float));
+    tmp = glyph_z_order++;
+    memcpy(&glyph_data[1], &tmp, sizeof(float));
+    glyph_data[2] = gx;
+    glyph_data[3] = gy;
+    glyph_data[4] = ts->font_size;
+    uint32_t packed_gf = (glyph_index & 0xFFFF) |
+                         (((uint32_t)(ts->font_id + 1) & 0xFFFF) << 16);
+    memcpy(&glyph_data[5], &packed_gf, sizeof(float));
+    memcpy(&glyph_data[6], &ts->color, sizeof(float));
+
+    float abs_y = gy + canvas->cursor_row * canvas->cell_size.height;
+    float abs_y_max = abs_y + gh;
+    uint32_t glyph_row_max =
+        (uint32_t)(abs_y_max / canvas->cell_size.height);
+
+    canvas_ensure_lines(canvas, glyph_row_max + 1);
+
+    uint32_t rolling_row = canvas->rolling_row_0 + canvas->cursor_row;
+
+    struct yetty_ypaint_canvas_grid_line *base_line =
+        line_buffer_get(&canvas->lines, glyph_row_max);
+    if (!base_line) {
+      cursor_x += advance * scale;
+      continue;
+    }
+
+    uint32_t prim_idx = prim_data_array_push(&base_line->prims,
+                                             rolling_row, glyph_data,
+                                             YPAINT_GLYPH_WORDS);
+
+    uint32_t col_min = (canvas->cell_size.width > 0)
+        ? (uint32_t)(gx / canvas->cell_size.width) : 0;
+    uint32_t col_max = (canvas->cell_size.width > 0)
+        ? (uint32_t)((gx + gw) / canvas->cell_size.width) : 0;
+    uint32_t row_min = (uint32_t)(abs_y / canvas->cell_size.height);
+
+    if (col_max >= canvas->grid_size.cols && canvas->grid_size.cols > 0)
+      col_max = canvas->grid_size.cols - 1;
+
+    for (uint32_t row = row_min; row <= glyph_row_max; row++) {
+      struct yetty_ypaint_canvas_grid_line *line =
+          line_buffer_get(&canvas->lines, row);
+      grid_line_ensure_cells(line, col_max + 1);
+      uint16_t lines_ahead = (uint16_t)(glyph_row_max - row);
+      for (uint32_t col = col_min; col <= col_max; col++) {
+        struct yetty_ypaint_canvas_prim_ref ref = {
+            lines_ahead, (uint16_t)prim_idx};
+        prim_ref_array_push(&line->cells[col].refs, ref);
+      }
+    }
+
+    if (glyph_row_max > glyph_max_row)
+      glyph_max_row = glyph_row_max;
+
+    cursor_x += advance * scale;
+  }
+
+  return glyph_max_row;
+}
+
+/* Attach `font` to the grid line at `glyph_max_row`. If the same font
+ * was previously attached to a higher (older) line, migrate it down.
+ * Skip when font is NULL or is the canvas's default font. */
+static void attach_font_to_line(struct yetty_ypaint_canvas *canvas,
+                                struct yetty_font_font *font,
+                                int32_t font_id,
+                                uint32_t glyph_max_row,
+                                struct font_map *fonts_map) {
+  if (!font || font == canvas->default_font || glyph_max_row == 0)
+    return;
+  struct yetty_ypaint_canvas_grid_line *target =
+      line_buffer_get(&canvas->lines, glyph_max_row);
+  if (!target)
+    return;
+
+  bool found = false;
+  for (uint32_t li = 0; li < canvas->lines.count && !found; li++) {
+    struct yetty_ypaint_canvas_grid_line *l = &canvas->lines.lines[li];
+    for (uint32_t fi = 0; fi < l->font_count; fi++) {
+      if (l->fonts[fi].font == font) {
+        if (li != glyph_max_row) {
+          if (target->font_count >= target->font_capacity) {
+            uint32_t new_cap = target->font_capacity == 0
+                ? 4 : target->font_capacity * 2;
+            target->fonts = realloc(target->fonts,
+                new_cap * sizeof(struct yetty_ypaint_canvas_font_entry));
+            target->font_capacity = new_cap;
+          }
+          target->fonts[target->font_count++] = l->fonts[fi];
+          l->fonts[fi] = l->fonts[--l->font_count];
+        }
+        found = true;
+        break;
+      }
+    }
+  }
+  if (!found) {
+    if (target->font_count >= target->font_capacity) {
+      uint32_t new_cap = target->font_capacity == 0
+          ? 4 : target->font_capacity * 2;
+      target->fonts = realloc(target->fonts,
+          new_cap * sizeof(struct yetty_ypaint_canvas_font_entry));
+      target->font_capacity = new_cap;
+    }
+    struct yetty_ypaint_canvas_font_entry entry = {0};
+    entry.font = font;
+    entry.font_id = font_id;
+    target->fonts[target->font_count++] = entry;
+    /* Ownership transferred to the line — drop from the local map so
+     * the post-loop cleanup doesn't double-free. */
+    if (font_id >= 0 && (uint32_t)font_id < fonts_map->capacity)
+      fonts_map->fonts[font_id] = NULL;
+  }
+}
+
 struct yetty_ycore_void_result
 yetty_ypaint_canvas_add_buffer(struct yetty_ypaint_canvas *canvas,
                                struct yetty_ypaint_core_buffer *buffer) {
@@ -948,92 +1252,61 @@ yetty_ypaint_canvas_add_buffer(struct yetty_ypaint_canvas *canvas,
     return YETTY_ERR(yetty_ycore_void, "buffer is NULL");
   }
 
-  // Check if buffer has SDF primitives (text spans handled separately in PASS 4)
   struct yetty_ypaint_core_primitive_iter_result iter_res =
       yetty_ypaint_core_buffer_prim_first(buffer, canvas->flyweight_registry);
-  bool has_sdf_primitives = YETTY_IS_OK(iter_res);
+  bool has_primitives = YETTY_IS_OK(iter_res);
 
-  // Save original cursor - primitives coords are relative to THIS position
   uint16_t original_cursor_row = canvas->cursor_row;
-  uint32_t original_rolling_row_0 = canvas->rolling_row_0;
-  (void)original_rolling_row_0;
 
-  ydebug("add_buffer: START cursor_row=%u grid_rows=%u rolling_row_0=%u has_sdf=%d",
+  ydebug("add_buffer: START cursor_row=%u grid_rows=%u rolling_row_0=%u has_prims=%d",
          canvas->cursor_row, canvas->grid_size.rows, canvas->rolling_row_0,
-         has_sdf_primitives);
+         has_primitives);
+
+  if (!has_primitives) {
+    canvas->dirty = true;
+    return YETTY_OK_VOID();
+  }
 
   uint16_t lines_scrolled = 0;
   uint32_t max_row_seen = 0;
 
-  // PASS 1: Compute max_row needed for ALL content (SDF + text spans)
+  /* PASS 1 — walk every primitive once, take the AABB max-y. Type-agnostic:
+   * every prim has an aabb via its base ops (FONT returns an empty rect, so
+   * it doesn't push max_row up). */
   uint32_t max_row_needed = 0;
   float cursor_y_offset = original_cursor_row * canvas->cell_size.height;
-
-  // PASS 1a: SDF primitives
-  if (has_sdf_primitives) {
+  {
     struct yetty_ypaint_core_primitive_iter iter = iter_res.value;
-
     while (1) {
-      if (!iter.fw.ops->aabb)
-        break;
-      struct rectangle_result aabb_res = iter.fw.ops->aabb(iter.fw.data);
-      if (YETTY_IS_ERR(aabb_res))
-        break;
-      struct rectangle aabb = aabb_res.value;
-
-      float abs_max_y = aabb.max.y + cursor_y_offset;
-      uint32_t prim_max_row =
-          (canvas->cell_size.height > 0)
-              ? (uint32_t)floorf(abs_max_y / canvas->cell_size.height)
-              : 0;
-
-      if (prim_max_row > max_row_needed)
-        max_row_needed = prim_max_row;
-
-      iter_res = yetty_ypaint_core_buffer_prim_next(buffer, canvas->flyweight_registry, &iter);
-      if (YETTY_IS_ERR(iter_res))
-        break;
-      iter = iter_res.value;
+      if (iter.fw.ops->aabb) {
+        struct rectangle_result aabb_res = iter.fw.ops->aabb(iter.fw.data);
+        if (YETTY_IS_OK(aabb_res)) {
+          float abs_max_y = aabb_res.value.max.y + cursor_y_offset;
+          uint32_t prim_max_row =
+              (canvas->cell_size.height > 0)
+                  ? (uint32_t)floorf(abs_max_y / canvas->cell_size.height)
+                  : 0;
+          if (prim_max_row > max_row_needed)
+            max_row_needed = prim_max_row;
+        }
+      }
+      struct yetty_ypaint_core_primitive_iter_result nx =
+          yetty_ypaint_core_buffer_prim_next(buffer,
+                                             canvas->flyweight_registry, &iter);
+      if (YETTY_IS_ERR(nx)) break;
+      iter = nx.value;
     }
-  }
-
-  // PASS 1b: Text spans - estimate max row from position + font size
-  uint32_t span_count = yetty_ypaint_core_buffer_text_span_count(buffer);
-  for (uint32_t si = 0; si < span_count; si++) {
-    const struct yetty_text_span *ts =
-        yetty_ypaint_core_buffer_get_text_span(buffer, si);
-    if (!ts || !ts->named_buf.buf.data || ts->named_buf.buf.size == 0)
-      continue;
-
-    // Estimate: baseline at ts->y, glyph extends ~font_size below baseline
-    // (conservative estimate - actual depends on font metrics)
-    float estimated_max_y = ts->y + ts->font_size;
-    float abs_max_y = estimated_max_y + cursor_y_offset;
-    uint32_t text_max_row =
-        (canvas->cell_size.height > 0)
-            ? (uint32_t)floorf(abs_max_y / canvas->cell_size.height)
-            : 0;
-
-    if (text_max_row > max_row_needed)
-      max_row_needed = text_max_row;
   }
 
   ydebug("add_buffer: PASS1 max_row_needed=%u (cursor at row %u)",
          max_row_needed, original_cursor_row);
 
-  // SCROLL if content extends beyond visible area (scrolling mode only).
-  // In overlay (non-scrolling) mode the cursor is driven externally by the
-  // text layer; the canvas neither scrolls itself nor asks others to scroll.
-  // Content that does not fit at the current cursor is left to be clipped
-  // by the shader (cells past grid_size.rows are never read) and by the
-  // complex-prim visibility loops (which cap at grid_size.rows).
+  /* Scroll if the buffer reaches past the visible grid (scrolling mode only).
+   * Overlay mode has its cursor driven externally — never scroll there. */
   uint32_t target_cursor_row = max_row_needed + 1;
   if (canvas->scrolling_mode &&
       target_cursor_row >= canvas->grid_size.rows) {
     lines_scrolled = (uint16_t)(target_cursor_row - canvas->grid_size.rows + 1);
-
-    ydebug("add_buffer: SCROLL NEEDED target=%u >= grid_rows=%u, scroll %u",
-           target_cursor_row, canvas->grid_size.rows, lines_scrolled);
 
     if (!canvas->scroll_callback) {
       yerror("yetty_ypaint_canvas_add_buffer: scroll_callback is NULL");
@@ -1041,320 +1314,115 @@ yetty_ypaint_canvas_add_buffer(struct yetty_ypaint_canvas *canvas,
     }
     struct yetty_ycore_void_result scroll_res = canvas->scroll_callback(
         canvas->scroll_callback_user_data, lines_scrolled);
-    if (YETTY_IS_ERR(scroll_res)) {
-      yerror("yetty_ypaint_canvas_add_buffer: scroll_callback failed");
+    if (YETTY_IS_ERR(scroll_res))
       return scroll_res;
-    }
-
     yetty_ypaint_canvas_scroll_lines(canvas, lines_scrolled);
-
-    ydebug("add_buffer: after scroll cursor_row=%u rolling_row_0=%u",
-           canvas->cursor_row, canvas->rolling_row_0);
   }
 
-  // PASS 2: Add SDF primitives with adjusted cursor
   uint16_t adjusted_cursor = (original_cursor_row >= lines_scrolled)
                                  ? (original_cursor_row - lines_scrolled)
                                  : 0;
   canvas->cursor_row = adjusted_cursor;
 
-  if (has_sdf_primitives) {
-    ydebug("add_buffer: PASS2 using adjusted cursor_row=%u (original=%u - "
-           "scrolled=%u)",
-           adjusted_cursor, original_cursor_row, lines_scrolled);
+  /* PASS 2 — single dispatch loop. Type word at prim[0] picks the path:
+   *   FONT       → materialize, record in fonts_map (no grid placement)
+   *   TEXT_SPAN  → resolve font, decompose into glyph SDF prims
+   *   else (SDF, complex) → add_primitive_internal
+   */
+  struct font_map fonts_map;
+  font_map_init(&fonts_map);
 
-    iter_res = yetty_ypaint_core_buffer_prim_first(buffer, canvas->flyweight_registry);
-    struct yetty_ypaint_core_primitive_iter iter = iter_res.value;
+  iter_res = yetty_ypaint_core_buffer_prim_first(
+      buffer, canvas->flyweight_registry);
+  struct yetty_ypaint_core_primitive_iter iter = iter_res.value;
+  struct yetty_ycore_void_result final_status = YETTY_OK_VOID();
 
-    while (1) {
+  while (1) {
+    uint32_t prim_type = iter.fw.data[0];
+
+    if (prim_type == YETTY_YPAINT_TYPE_FONT) {
+      struct yetty_ypaint_font_prim_view fv;
+      if (yetty_ypaint_font_prim_parse(iter.fw.data, &fv) == 0) {
+        char hint[YETTY_YCORE_NAMED_BUFFER_MAX_NAME_LENGTH];
+        size_t hl = fv.name_len < sizeof(hint) - 1
+                        ? fv.name_len : sizeof(hint) - 1;
+        memcpy(hint, fv.name, hl);
+        hint[hl] = '\0';
+
+        struct yetty_font_font_result fr =
+            ypaint_canvas_materialize_blob_font(canvas, fv.ttf, fv.ttf_len,
+                                                hint);
+        if (YETTY_IS_ERR(fr)) {
+          yerror("add_buffer: font materialize failed: %s", fr.error.msg);
+          final_status = YETTY_ERR(yetty_ycore_void, fr.error.msg);
+          break;
+        }
+        if (fv.font_id >= 0) {
+          font_map_grow(&fonts_map, (uint32_t)fv.font_id + 1);
+          fonts_map.fonts[fv.font_id] = fr.value;
+        } else {
+          /* Producer didn't tag — drop it. */
+          fr.value->ops->destroy(fr.value);
+        }
+      }
+    } else if (prim_type == YETTY_YPAINT_TYPE_TEXT_SPAN) {
+      struct yetty_ypaint_text_span_prim_view tv;
+      if (yetty_ypaint_text_span_prim_parse(iter.fw.data, &tv) == 0) {
+        struct yetty_font_font *font = NULL;
+        if (tv.font_id >= 0)
+          font = font_map_get(&fonts_map, (uint32_t)tv.font_id);
+        if (!font && tv.font_id == -1)
+          font = canvas->default_font;
+        if (!font) {
+          /* Fall back to the canvas default rather than failing the whole
+           * buffer — keeps PDFs with unknown font_ids partially renderable. */
+          font = canvas->default_font;
+        }
+        if (font) {
+          uint32_t glyph_max_row =
+              expand_text_span_to_glyphs(canvas, &tv, font);
+          if (glyph_max_row > max_row_seen)
+            max_row_seen = glyph_max_row;
+          attach_font_to_line(canvas, font, tv.font_id, glyph_max_row,
+                              &fonts_map);
+        }
+      }
+    } else {
+      /* SDF or complex prim — uniform path. */
       struct uint32_result prim_res = add_primitive_internal(canvas, &iter);
       if (YETTY_IS_ERR(prim_res)) {
         yerror("add_buffer: add_primitive_internal failed: %s",
                prim_res.error.msg);
-        return YETTY_ERR(yetty_ycore_void, prim_res.error.msg);
-      }
-      uint32_t prim_max_row = prim_res.value;
-
-      ydebug("add_buffer: PASS2 added prim type=%u max_row=%u", iter.fw.data[0],
-             prim_max_row);
-
-      if (prim_max_row > max_row_seen)
-        max_row_seen = prim_max_row;
-
-      iter_res = yetty_ypaint_core_buffer_prim_next(buffer, canvas->flyweight_registry, &iter);
-      if (YETTY_IS_ERR(iter_res))
+        final_status = YETTY_ERR(yetty_ycore_void, prim_res.error.msg);
         break;
-      iter = iter_res.value;
-    }
-  } // end if (has_sdf_primitives)
-
-  // PASS 3: Process font blobs → create font objects.
-  // Font kind (MSDF vs raster) is decided by the blob name's extension;
-  // unrecognised extensions fall back to the canvas-configured render method.
-  uint32_t font_count = yetty_ypaint_core_buffer_font_count(buffer);
-  struct yetty_font_font **fonts = NULL;
-  if (font_count > 0) {
-    fonts = calloc(font_count, sizeof(struct yetty_font_font *));
-    for (uint32_t i = 0; i < font_count; i++) {
-      const struct yetty_font_blob *fb =
-          yetty_ypaint_core_buffer_get_font(buffer, i);
-      if (!fb || !fb->named_buf.buf.data) continue;
-      struct yetty_font_font_result fr =
-          ypaint_canvas_make_blob_font(canvas, fb->named_buf.name);
-      if (YETTY_IS_ERR(fr)) {
-        yerror("add_buffer: font creation failed: %s", fr.error.msg);
-        free(fonts);
-        return YETTY_ERR(yetty_ycore_void, fr.error.msg);
       }
-      fonts[i] = fr.value;
+      if (prim_res.value > max_row_seen)
+        max_row_seen = prim_res.value;
     }
+
+    struct yetty_ypaint_core_primitive_iter_result nx =
+        yetty_ypaint_core_buffer_prim_next(buffer,
+                                           canvas->flyweight_registry, &iter);
+    if (YETTY_IS_ERR(nx)) break;
+    iter = nx.value;
   }
 
-  // PASS 4: Process text spans → decompose into glyph primitives
-  // (span_count already computed in PASS 1b)
-  ydebug("add_buffer: PASS4 span_count=%u default_font=%p",
-         span_count, (void *)canvas->default_font);
-  for (uint32_t si = 0; si < span_count; si++) {
-    const struct yetty_text_span *ts =
-        yetty_ypaint_core_buffer_get_text_span(buffer, si);
-    if (!ts || !ts->named_buf.buf.data || ts->named_buf.buf.size == 0)
-      continue;
-
-    ydebug("add_buffer: PASS4 span[%u] font_id=%d x=%.1f y=%.1f",
-           si, ts->font_id, ts->x, ts->y);
-
-    struct yetty_font_font *font = NULL;
-    if (ts->font_id >= 0 && (uint32_t)ts->font_id < font_count)
-      font = fonts[ts->font_id];
-    if (!font && ts->font_id == -1)
-      font = canvas->default_font;
-    if (!font) {
-      yerror("add_buffer: span[%u] font_id=%d not found and no default", si, ts->font_id);
-      if (fonts) free(fonts);
-      return YETTY_ERR(yetty_ycore_void, "text span font not found");
-    }
-
-    float base_size = font->ops->get_base_size(font);
-    float scale = (base_size > 0) ? ts->font_size / base_size : 1.0f;
-    float cursor_x = ts->x;
-    uint32_t glyph_max_row = 0;
-
-    const uint8_t *ptr = ts->named_buf.buf.data;
-    const uint8_t *end = ptr + ts->named_buf.buf.size;
-
-    while (ptr < end) {
-      /* UTF-8 decode */
-      uint32_t cp = 0;
-      if ((*ptr & 0x80) == 0) {
-        cp = *ptr++;
-      } else if ((*ptr & 0xE0) == 0xC0) {
-        cp = (*ptr++ & 0x1F) << 6;
-        if (ptr < end) cp |= (*ptr++ & 0x3F);
-      } else if ((*ptr & 0xF0) == 0xE0) {
-        cp = (*ptr++ & 0x0F) << 12;
-        if (ptr < end) cp |= (*ptr++ & 0x3F) << 6;
-        if (ptr < end) cp |= (*ptr++ & 0x3F);
-      } else if ((*ptr & 0xF8) == 0xF0) {
-        cp = (*ptr++ & 0x07) << 18;
-        if (ptr < end) cp |= (*ptr++ & 0x3F) << 12;
-        if (ptr < end) cp |= (*ptr++ & 0x3F) << 6;
-        if (ptr < end) cp |= (*ptr++ & 0x3F);
-      } else {
-        ptr++;
-        continue;
-      }
-
-      struct uint32_result gi_res = font->ops->get_glyph_index(font, cp);
-      if (YETTY_IS_ERR(gi_res)) {
-        ydebug("add_buffer: glyph_index FAILED cp=0x%x: %s", cp, gi_res.error.msg);
-        cursor_x += ts->font_size * 0.5f;
-        continue;
-      }
-      uint32_t glyph_index = gi_res.value;
-
-      /* Read glyph metadata from font's metadata buffer */
-      struct yetty_yrender_gpu_resource_set_result rs_res =
-          font->ops->get_gpu_resource_set(font);
-      if (YETTY_IS_ERR(rs_res)) {
-        ydebug("add_buffer: get_gpu_resource_set FAILED: %s", rs_res.error.msg);
-        continue;
-      }
-      const struct yetty_yrender_gpu_resource_set *rs = rs_res.value;
-      if (rs->buffer_count == 0 || !rs->buffers[0].data) {
-        ydebug("add_buffer: no buffer data buf_count=%zu data=%p", rs->buffer_count, (void*)rs->buffers[0].data);
-        continue;
-      }
-
-      /* Metadata: 6 floats per glyph [size_x, size_y, bearing_x, bearing_y, advance, _pad] */
-      const float *meta = (const float *)rs->buffers[0].data;
-      uint32_t meta_count = (uint32_t)(rs->buffers[0].size / (6 * sizeof(float)));
-      ydebug("add_buffer: cp=0x%x glyph_index=%u meta_count=%u buf_size=%zu", cp, glyph_index, meta_count, rs->buffers[0].size);
-      if (glyph_index >= meta_count) {
-        ydebug("add_buffer: glyph_index %u >= meta_count %u, skipping", glyph_index, meta_count);
-        cursor_x += ts->font_size * 0.5f;
-        continue;
-      }
-
-      const float *gm = meta + glyph_index * 6;
-      float size_x = gm[0], size_y = gm[1];
-      float bearing_x = gm[2], bearing_y = gm[3];
-      float advance = gm[4];
-
-      /* Skip empty glyphs (space, etc.) - just advance cursor */
-      if (size_x <= 0.0f || size_y <= 0.0f) {
-        cursor_x += advance * scale;
-        continue;
-      }
-
-      float gx = cursor_x + bearing_x * scale;
-      float gy = ts->y - bearing_y * scale;
-      float gw = size_x * scale;
-      float gh = size_y * scale;
-
-      /* Pack glyph primitive (7 words): type, z_order, x, y, font_size, packed, color */
-      static uint32_t glyph_z_order = 0;
-      float glyph_data[YPAINT_GLYPH_WORDS];
-      uint32_t tmp;
-      tmp = YETTY_YSDF_GLYPH;
-      memcpy(&glyph_data[0], &tmp, sizeof(float));
-      tmp = glyph_z_order++;
-      memcpy(&glyph_data[1], &tmp, sizeof(float));
-      glyph_data[2] = gx;
-      glyph_data[3] = gy;
-      glyph_data[4] = ts->font_size;  /* target render size */
-      /* Pack glyph_index (16 bits) | font_id (16 bits) */
-      uint32_t packed_gf = (glyph_index & 0xFFFF) |
-                           (((uint32_t)(ts->font_id + 1) & 0xFFFF) << 16);
-      memcpy(&glyph_data[5], &packed_gf, sizeof(float));
-      /* Color */
-      uint32_t color = ts->color.r | (ts->color.g << 8) |
-                       (ts->color.b << 16) | (ts->color.a << 24);
-      memcpy(&glyph_data[6], &color, sizeof(float));
-
-      /* Compute glyph AABB in absolute coords */
-      float abs_y = gy + canvas->cursor_row * canvas->cell_size.height;
-      float abs_y_max = abs_y + gh;
-      uint32_t glyph_row_max =
-          (uint32_t)(abs_y_max / canvas->cell_size.height);
-
-      canvas_ensure_lines(canvas, glyph_row_max + 1);
-
-      uint32_t rolling_row = canvas->rolling_row_0 + canvas->cursor_row;
-
-      /* Store glyph as primitive at its max row */
-      struct yetty_ypaint_canvas_grid_line *base_line =
-          line_buffer_get(&canvas->lines, glyph_row_max);
-      if (!base_line) goto next_glyph;
-
-      uint32_t prim_idx = prim_data_array_push(&base_line->prims,
-                                               rolling_row, glyph_data,
-                                               YPAINT_GLYPH_WORDS);
-
-      /* Register in grid cells */
-      uint32_t col_min = (canvas->cell_size.width > 0)
-          ? (uint32_t)(gx / canvas->cell_size.width) : 0;
-      uint32_t col_max = (canvas->cell_size.width > 0)
-          ? (uint32_t)((gx + gw) / canvas->cell_size.width) : 0;
-      uint32_t row_min = (uint32_t)(abs_y / canvas->cell_size.height);
-
-      if (col_max >= canvas->grid_size.cols && canvas->grid_size.cols > 0)
-        col_max = canvas->grid_size.cols - 1;
-
-      for (uint32_t row = row_min; row <= glyph_row_max; row++) {
-        struct yetty_ypaint_canvas_grid_line *line =
-            line_buffer_get(&canvas->lines, row);
-        grid_line_ensure_cells(line, col_max + 1);
-        uint16_t lines_ahead = (uint16_t)(glyph_row_max - row);
-        for (uint32_t col = col_min; col <= col_max; col++) {
-          struct yetty_ypaint_canvas_prim_ref ref = {
-              lines_ahead, (uint16_t)prim_idx};
-          prim_ref_array_push(&line->cells[col].refs, ref);
-        }
-      }
-
-      if (glyph_row_max > glyph_max_row)
-        glyph_max_row = glyph_row_max;
-      if (glyph_row_max > max_row_seen)
-        max_row_seen = glyph_row_max;
-
-next_glyph:
-      cursor_x += advance * scale;
-    }
-
-    /* Attach font to the lowest row this span's glyphs reach.
-     * Skip default font - it's owned by canvas, not by lines. */
-    if (font && font != canvas->default_font && glyph_max_row > 0) {
-      struct yetty_ypaint_canvas_grid_line *target_line =
-          line_buffer_get(&canvas->lines, glyph_max_row);
-      if (target_line) {
-        /* Check if font already attached to a higher line — move it down */
-        bool found = false;
-        for (uint32_t li = 0; li < canvas->lines.count && !found; li++) {
-          struct yetty_ypaint_canvas_grid_line *l =
-              &canvas->lines.lines[li];
-          for (uint32_t fi = 0; fi < l->font_count; fi++) {
-            if (l->fonts[fi].font == font) {
-              /* Move from old line to target line */
-              if (li != glyph_max_row) {
-                /* Add to target */
-                if (target_line->font_count >= target_line->font_capacity) {
-                  uint32_t new_cap = target_line->font_capacity == 0
-                      ? 4 : target_line->font_capacity * 2;
-                  target_line->fonts = realloc(target_line->fonts,
-                      new_cap * sizeof(struct yetty_ypaint_canvas_font_entry));
-                  target_line->font_capacity = new_cap;
-                }
-                target_line->fonts[target_line->font_count++] = l->fonts[fi];
-                /* Remove from old line */
-                l->fonts[fi] = l->fonts[--l->font_count];
-              }
-              found = true;
-              break;
-            }
-          }
-        }
-        if (!found) {
-          /* First time — attach to target line */
-          if (target_line->font_count >= target_line->font_capacity) {
-            uint32_t new_cap = target_line->font_capacity == 0
-                ? 4 : target_line->font_capacity * 2;
-            target_line->fonts = realloc(target_line->fonts,
-                new_cap * sizeof(struct yetty_ypaint_canvas_font_entry));
-            target_line->font_capacity = new_cap;
-          }
-          struct yetty_ypaint_canvas_font_entry entry = {0};
-          entry.font = font;
-          entry.font_id = ts->font_id;
-          target_line->fonts[target_line->font_count++] = entry;
-          /* Null out from fonts array so it's not double-freed */
-          if (ts->font_id >= 0 && (uint32_t)ts->font_id < font_count)
-            fonts[ts->font_id] = NULL;
-        }
-      }
-    }
+  /* Free fonts that didn't get attached to a grid line (typically fonts
+   * referenced only by spans we couldn't render, or none at all). */
+  for (uint32_t i = 0; i < fonts_map.capacity; i++) {
+    if (fonts_map.fonts[i] && fonts_map.fonts[i]->ops)
+      fonts_map.fonts[i]->ops->destroy(fonts_map.fonts[i]);
   }
+  free(fonts_map.fonts);
 
-  /* Free any fonts not attached to grid lines */
-  if (fonts) {
-    for (uint32_t i = 0; i < font_count; i++) {
-      if (fonts[i] && fonts[i]->ops)
-        fonts[i]->ops->destroy(fonts[i]);
-    }
-    free(fonts);
-  }
+  if (YETTY_IS_ERR(final_status))
+    return final_status;
 
-  // Set final cursor position = row after max primitive row.
-  // Only meaningful in scrolling mode — in overlay mode the cursor is driven
-  // by the text layer and the canvas must not push it around.
   if (canvas->scrolling_mode) {
     uint32_t final_cursor = max_row_seen + 1;
-    if (final_cursor >= canvas->grid_size.rows) {
-      // Shouldn't happen since we scrolled, but clamp just in case
+    if (final_cursor >= canvas->grid_size.rows)
       final_cursor = canvas->grid_size.rows - 1;
-    }
     canvas->cursor_row = (uint16_t)final_cursor;
-
-    // Notify text layer of final cursor position
     if (canvas->cursor_set_callback) {
       canvas->cursor_set_callback(canvas->cursor_set_callback_user_data,
                                   canvas->cursor_row);

--- a/test/ut/ypdf/CMakeLists.txt
+++ b/test/ut/ypdf/CMakeLists.txt
@@ -22,8 +22,8 @@ target_include_directories(ypdf-render-test PRIVATE
     ${YETTY_ROOT}/src
 )
 target_link_libraries(ypdf-render-test PRIVATE
-    yetty_ypdf yetty_ypaint_core yetty_yfont yetty_ycore yetty_yrender
-    pdfio_lib)
+    yetty_ypdf yetty_ypaint yetty_ypaint_core yetty_yfont yetty_ycore
+    yetty_yrender pdfio_lib ytrace::ytrace)
 target_compile_definitions(ypdf-render-test PRIVATE
     YPDF_TEST_PDF=\"${CMAKE_CURRENT_SOURCE_DIR}/test-comprehensive.pdf\"
 )
@@ -39,7 +39,7 @@ target_include_directories(ypdf-font-test PRIVATE
     ${YETTY_ROOT}/src
 )
 target_link_libraries(ypdf-font-test PRIVATE
-    yetty_yfont yetty_ycore yetty_yrender)
+    yetty_yfont yetty_ycore yetty_yrender ytrace::ytrace)
 target_compile_definitions(ypdf-font-test PRIVATE
     YPDF_TEST_TTF=\"${YETTY_ROOT}/assets/fonts/DejaVuSansMNerdFontMono-Regular.ttf\"
 )

--- a/test/ut/ypdf/ypdf-render-test.c
+++ b/test/ut/ypdf/ypdf-render-test.c
@@ -5,13 +5,20 @@
  * validates the resulting ypaint buffer:
  *   - pages are counted correctly
  *   - scene bounds reflect the accumulated page heights
- *   - at least one TTF font was extracted (test PDF embeds fonts)
- *   - at least one text span was emitted
- *   - the primitive byte buffer is non-empty (rectangles/segments present)
+ *   - at least one FONT prim was emitted (test PDF embeds fonts)
+ *   - at least one TEXT_SPAN prim was emitted
+ *
+ * After the buffer/handler refactor, fonts and text spans live in the
+ * primitive byte stream alongside SDF prims. We count them by iterating
+ * with a flyweight registry that has the FONT/TEXT_SPAN handlers
+ * registered (yetty_ypaint_flyweight_create() does that).
  */
 
 #include <pdfio.h>
 #include <yetty/ypaint-core/buffer.h>
+#include <yetty/ypaint-core/font-prim.h>
+#include <yetty/ypaint-core/text-span-prim.h>
+#include <yetty/ypaint/flyweight.h>
 #include <yetty/ypdf/ypdf.h>
 
 #include <stdio.h>
@@ -36,6 +43,35 @@ static bool error_cb(pdfio_file_t *f, const char *s, void *d) {
     return true;
 }
 
+struct prim_counts {
+    uint32_t fonts;
+    uint32_t text_spans;
+    uint32_t other;
+};
+
+static struct prim_counts count_prims(struct yetty_ypaint_core_buffer *buf,
+                                      struct yetty_ypaint_flyweight_registry *reg)
+{
+    struct prim_counts c = {0};
+    struct yetty_ypaint_core_primitive_iter_result ir =
+        yetty_ypaint_core_buffer_prim_first(buf, reg);
+    if (YETTY_IS_ERR(ir))
+        return c;
+    struct yetty_ypaint_core_primitive_iter it = ir.value;
+    for (;;) {
+        uint32_t t = it.fw.data[0];
+        if (t == YETTY_YPAINT_TYPE_FONT)            c.fonts++;
+        else if (t == YETTY_YPAINT_TYPE_TEXT_SPAN)  c.text_spans++;
+        else                                        c.other++;
+
+        struct yetty_ypaint_core_primitive_iter_result nx =
+            yetty_ypaint_core_buffer_prim_next(buf, reg, &it);
+        if (YETTY_IS_ERR(nx)) break;
+        it = nx.value;
+    }
+    return c;
+}
+
 int main(void) {
     pdfio_file_t *pdf = pdfioFileOpen(YPDF_TEST_PDF, NULL, NULL,
                                       error_cb, NULL);
@@ -50,26 +86,26 @@ int main(void) {
     REQUIRE(out->total_height > 0.0f, "total_height not set");
     REQUIRE(out->max_width > 0.0f, "max_width not set");
 
-    /* Scene bounds should match the renderer output. */
     float sx = yetty_ypaint_core_buffer_scene_max_x(out->buffer);
     float sy = yetty_ypaint_core_buffer_scene_max_y(out->buffer);
     REQUIRE(sx == out->max_width, "scene max_x mismatch");
     REQUIRE(sy == out->total_height, "scene max_y mismatch");
 
-    /* Test PDF embeds fonts, expect at least one to be captured. */
-    REQUIRE(yetty_ypaint_core_buffer_font_count(out->buffer) >= 1,
-            "no fonts extracted");
+    struct yetty_ypaint_flyweight_registry_ptr_result rr =
+        yetty_ypaint_flyweight_create();
+    REQUIRE(YETTY_IS_OK(rr), "flyweight_create failed");
+    struct yetty_ypaint_flyweight_registry *reg = rr.value;
 
-    /* At least one text span. */
-    REQUIRE(yetty_ypaint_core_buffer_text_span_count(out->buffer) >= 1,
-            "no text spans emitted");
+    struct prim_counts c = count_prims(out->buffer, reg);
+    REQUIRE(c.fonts >= 1, "no FONT prims in buffer");
+    REQUIRE(c.text_spans >= 1, "no TEXT_SPAN prims in buffer");
 
-    printf("OK: %d pages, %u fonts, %u text spans, total_h=%.1f\n",
-           out->page_count,
-           yetty_ypaint_core_buffer_font_count(out->buffer),
-           yetty_ypaint_core_buffer_text_span_count(out->buffer),
+    printf("OK: %d pages, %u FONT prims, %u TEXT_SPAN prims, %u other, "
+           "total_h=%.1f\n",
+           out->page_count, c.fonts, c.text_spans, c.other,
            out->total_height);
 
+    yetty_ypaint_flyweight_registry_destroy(reg);
     yetty_ypaint_core_buffer_destroy(out->buffer);
     pdfioFileClose(pdf);
     return 0;


### PR DESCRIPTION
## Summary

Refactors the ypaint buffer so embedded fonts (PDF) and text runs travel through the OSC wire as first-class primitives, then materializes them on the receiving side. Before this, fonts and text spans lived in side arrays on the buffer struct, which the framed wire format silently dropped — PDFs ycat'd into a yetty terminal had never displayed.

- New flyweight tier at `[0x40000000, 0x7FFFFFFF]` between simple SDF (`[0x00, 0xFF]`) and complex factory prims (`[0x80000000, 0xFFFFFFFF]`).
  - `YETTY_YPAINT_TYPE_FONT       = 0x40000001` — `font-prim.{h,c}`
  - `YETTY_YPAINT_TYPE_TEXT_SPAN  = 0x40000002` — `text-span-prim.{h,c}`
  - Each registers its own handler with the flyweight registry, like SDF and complex.
- `struct yetty_ypaint_core_buffer` becomes a single byte stream — no more `fonts[YPAINT_MAX_FONTS]` / `text_spans[YPAINT_MAX_TEXT_SPANS]` side arrays. `add_font` / `add_text` are thin wrappers that pack the FAM payload and call `add_prim`. Wire format collapses to `magic + scene_bounds + byte_count + raw_bytes`.
- `yetty_ypaint_canvas_add_buffer` collapses the previous SDF / text-span / font multi-pass logic into one dispatch loop driven by the prim type word.
- On encountering a FONT prim, the canvas content-addresses the TTF bytes (FNV-1a → `<cache>/ypaint-fonts/pdf_<hex>.ttf`), generates the MSDF CDB on miss via `ymsdf-gen`, and loads it. Cached across runs.

## Test plan

- [x] `ypdf-render-test` (unit): 3-page PDF → `1 FONT prim, 30 TEXT_SPAN prims, 147 SDF prims`.
- [x] `ycat README.md` inside `yetty` — renders.
- [x] `ycat src/yetty/ypaint-core/buffer.c` (tree-sitter path) inside `yetty` — renders.
- [x] `ycat test-comprehensive.pdf` inside `yetty` — renders.