### PR TITLE
3rdparty windows builds via MSYS2 CLANG64

### DIFF
--- a/.github/workflows/build-3rdparty-dav1d.yml
+++ b/.github/workflows/build-3rdparty-dav1d.yml
@@ -41,8 +41,8 @@ jobs:
           echo "tag=lib-dav1d-$V" >> "$GITHUB_OUTPUT"
 
   #===========================================================================
-  # Linux/Android/webasm — Ubuntu cross.
-  # (windows-x86_64 omitted — needs MSVC self-hosted runner.)
+  # Linux/Android/webasm — Ubuntu cross. windows-x86_64 builds on a
+  # GitHub-hosted windows-latest runner via msys2/setup-msys2 (CLANG64).
   #===========================================================================
   build-linux-cross:
     needs: resolve
@@ -119,6 +119,46 @@ jobs:
           TARGET_PLATFORM="${{ matrix.target }}" \
           OUTPUT_DIR="$PWD/out" \
           ./build-tools/3rdparty/dav1d/build.sh
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.resolve.outputs.tag }}
+          files: out/dav1d-${{ matrix.target }}-*.tar.gz
+          fail_on_unmatched_files: true
+
+  build-windows:
+    needs: resolve
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - windows-x86_64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: CLANG64
+          update: false
+          install: >-
+            git
+            tar
+            mingw-w64-clang-x86_64-clang
+            mingw-w64-clang-x86_64-lld
+            mingw-w64-clang-x86_64-meson
+            mingw-w64-clang-x86_64-ninja
+            mingw-w64-clang-x86_64-pkgconf
+            mingw-w64-clang-x86_64-nasm
+
+      - name: Build dav1d for ${{ matrix.target }}
+        shell: msys2 {0}
+        env:
+          TARGET_PLATFORM: ${{ matrix.target }}
+        run: |
+          mkdir -p out
+          OUTPUT_DIR="$(pwd)/out" \
+              ./build-tools/3rdparty/dav1d/build.sh
+
       - uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.resolve.outputs.tag }}

--- a/.github/workflows/build-3rdparty-openh264.yml
+++ b/.github/workflows/build-3rdparty-openh264.yml
@@ -133,3 +133,43 @@ jobs:
           tag_name: ${{ needs.resolve.outputs.tag }}
           files: out/openh264-${{ matrix.target }}-*.tar.gz
           fail_on_unmatched_files: true
+
+  # Windows: MSYS2 CLANG64 — clang + GNU make from msys2 base. openh264's
+  # mingw_nt platform make rules build natively without cross-prefixing.
+  build-windows:
+    needs: resolve
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - windows-x86_64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: CLANG64
+          update: false
+          install: >-
+            git
+            tar
+            make
+            mingw-w64-clang-x86_64-clang
+            mingw-w64-clang-x86_64-lld
+            mingw-w64-clang-x86_64-nasm
+
+      - name: Build openh264 for ${{ matrix.target }}
+        shell: msys2 {0}
+        env:
+          TARGET_PLATFORM: ${{ matrix.target }}
+        run: |
+          mkdir -p out
+          OUTPUT_DIR="$(pwd)/out" \
+              ./build-tools/3rdparty/openh264/build.sh
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.resolve.outputs.tag }}
+          files: out/openh264-${{ matrix.target }}-*.tar.gz
+          fail_on_unmatched_files: true

--- a/.github/workflows/build-3rdparty-openssl-new.yml
+++ b/.github/workflows/build-3rdparty-openssl-new.yml
@@ -125,3 +125,43 @@ jobs:
           tag_name: ${{ needs.resolve.outputs.tag }}
           files: out/openssl-new-${{ matrix.target }}-*.tar.gz
           fail_on_unmatched_files: true
+
+  # Windows: MSYS2 CLANG64 — clang + GNU make + perl (openssl's Configure
+  # is a perl script). The mingw64 openssl target uses gcc/clang naturally.
+  build-windows:
+    needs: resolve
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - windows-x86_64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: CLANG64
+          update: false
+          install: >-
+            git
+            tar
+            make
+            perl
+            mingw-w64-clang-x86_64-clang
+            mingw-w64-clang-x86_64-lld
+
+      - name: Build openssl-new for ${{ matrix.target }}
+        shell: msys2 {0}
+        env:
+          TARGET_PLATFORM: ${{ matrix.target }}
+        run: |
+          mkdir -p out
+          OUTPUT_DIR="$(pwd)/out" \
+              ./build-tools/3rdparty/openssl-new/build.sh
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.resolve.outputs.tag }}
+          files: out/openssl-new-${{ matrix.target }}-*.tar.gz
+          fail_on_unmatched_files: true

--- a/.github/workflows/build-3rdparty-openssl.yml
+++ b/.github/workflows/build-3rdparty-openssl.yml
@@ -133,3 +133,42 @@ jobs:
           tag_name: ${{ needs.resolve.outputs.tag }}
           files: out/openssl-${{ matrix.target }}-*.tar.gz
           fail_on_unmatched_files: true
+
+  # Windows: MSYS2 CLANG64 — clang + cmake + ninja from mingw-w64.
+  build-windows:
+    needs: resolve
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - windows-x86_64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: CLANG64
+          update: false
+          install: >-
+            git
+            tar
+            mingw-w64-clang-x86_64-clang
+            mingw-w64-clang-x86_64-lld
+            mingw-w64-clang-x86_64-cmake
+            mingw-w64-clang-x86_64-ninja
+
+      - name: Build openssl for ${{ matrix.target }}
+        shell: msys2 {0}
+        env:
+          TARGET_PLATFORM: ${{ matrix.target }}
+        run: |
+          mkdir -p out
+          OUTPUT_DIR="$(pwd)/out" \
+              ./build-tools/3rdparty/openssl/build.sh
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.resolve.outputs.tag }}
+          files: out/openssl-${{ matrix.target }}-*.tar.gz
+          fail_on_unmatched_files: true

--- a/build-tools/3rdparty/dav1d/_build.sh
+++ b/build-tools/3rdparty/dav1d/_build.sh
@@ -260,19 +260,14 @@ CROSS
     ;;
 
 windows-x86_64)
-    # Native MSVC — caller must have vcvarsall'd the shell.
-    CROSS_FILE="$WORK_DIR/native-windows.ini"
-    cat > "$CROSS_FILE" <<CROSS
-[binaries]
-c = 'cl'
-cpp = 'cl'
-ar = 'lib'
-
-[built-in options]
-c_args = []
-cpp_args = []
-CROSS
-    CROSS_FLAG="--native-file $CROSS_FILE"
+    # Native MSYS2 CLANG64 — caller must already be in the CLANG64 shell
+    # (CI: msys2/setup-msys2 with msystem: CLANG64). dav1d's regular
+    # native meson detection already picks up clang/llvm-ar from
+    # /clang64/bin without a cross/native file, so leave $CROSS_FLAG empty.
+    if [ "${MSYSTEM:-}" != "CLANG64" ]; then
+        echo "error: windows-x86_64 must run inside MSYS2 CLANG64 (MSYSTEM=${MSYSTEM:-unset})" >&2
+        exit 1
+    fi
     ;;
 
 *)
@@ -322,13 +317,12 @@ fi
 #-----------------------------------------------------------------------------
 # Verify install layout
 #-----------------------------------------------------------------------------
-case "$TARGET_PLATFORM" in
-    windows-x86_64) _LIB="$INSTALL_DIR/lib/dav1d.lib"  ;;
-    *)              _LIB="$INSTALL_DIR/lib/libdav1d.a" ;;
-esac
-# meson on windows also writes libdav1d.a in some configurations — accept either.
-if [ ! -f "$_LIB" ] && [ -f "$INSTALL_DIR/lib/libdav1d.a" ]; then
-    _LIB="$INSTALL_DIR/lib/libdav1d.a"
+# MSYS2 CLANG64 produces libdav1d.a (mingw convention) — same as POSIX
+# targets. The earlier MSVC case used dav1d.lib; we keep the fallback so
+# any future toolchain switch still validates.
+_LIB="$INSTALL_DIR/lib/libdav1d.a"
+if [ ! -f "$_LIB" ] && [ -f "$INSTALL_DIR/lib/dav1d.lib" ]; then
+    _LIB="$INSTALL_DIR/lib/dav1d.lib"
 fi
 if [ ! -f "$_LIB" ]; then
     echo "missing library: $_LIB" >&2

--- a/build-tools/3rdparty/dav1d/build.sh
+++ b/build-tools/3rdparty/dav1d/build.sh
@@ -28,8 +28,11 @@ case "$TARGET_PLATFORM" in
         SHELL_NAME="3rdparty-${TARGET_PLATFORM}"
         ;;
     windows-x86_64)
-        if ! command -v cl >/dev/null 2>&1 && ! command -v cl.exe >/dev/null 2>&1; then
-            echo "error: windows-x86_64 requires MSVC cl on PATH" >&2
+        # Windows uses MSYS2 CLANG64 — no nix shell. CI: msys2/setup-msys2
+        # with msystem: CLANG64; locally: any MSYS2 shell with
+        # `MSYSTEM=CLANG64 bash -lc ...`.
+        if [ "${MSYSTEM:-}" != "CLANG64" ]; then
+            echo "error: windows-x86_64 must run inside MSYS2 CLANG64 (MSYSTEM=${MSYSTEM:-unset})" >&2
             exit 1
         fi
         exec bash "$(dirname "$0")/_build.sh" "$@"

--- a/build-tools/3rdparty/openh264/_build.sh
+++ b/build-tools/3rdparty/openh264/_build.sh
@@ -190,9 +190,19 @@ webasm)
     ;;
 
 windows-x86_64)
-    # Cisco's Makefile supports OS=msvc — invoked through GNU make
-    # (chocolatey: `choco install make`) under a vcvarsall'd shell.
-    EXTRA_ARGS=(OS=msvc ARCH=x86_64)
+    # MSYS2 CLANG64 — use openh264's mingw_nt platform make rules with
+    # clang as the compiler. CI: msys2/setup-msys2 with msystem: CLANG64.
+    if [ "${MSYSTEM:-}" != "CLANG64" ]; then
+        echo "error: windows-x86_64 must run inside MSYS2 CLANG64 (MSYSTEM=${MSYSTEM:-unset})" >&2
+        exit 1
+    fi
+    EXTRA_ARGS=(
+        OS=mingw_nt
+        ARCH=x86_64
+        CC=clang
+        CXX=clang++
+        AR=llvm-ar
+    )
     ;;
 
 *)
@@ -221,10 +231,13 @@ fi
 #-----------------------------------------------------------------------------
 # Verify install layout
 #-----------------------------------------------------------------------------
-case "$TARGET_PLATFORM" in
-    windows-x86_64) _LIB="$INSTALL_DIR/lib/openh264.lib"     ;;
-    *)              _LIB="$INSTALL_DIR/lib/libopenh264.a"    ;;
-esac
+# mingw_nt builds produce libopenh264.a — same as POSIX targets. Keep
+# the openh264.lib fallback in case a future toolchain switch goes back
+# to MSVC naming.
+_LIB="$INSTALL_DIR/lib/libopenh264.a"
+if [ ! -f "$_LIB" ] && [ -f "$INSTALL_DIR/lib/openh264.lib" ]; then
+    _LIB="$INSTALL_DIR/lib/openh264.lib"
+fi
 
 if [ ! -f "$_LIB" ]; then
     echo "missing library: $_LIB" >&2

--- a/build-tools/3rdparty/openh264/build.sh
+++ b/build-tools/3rdparty/openh264/build.sh
@@ -29,11 +29,11 @@ case "$TARGET_PLATFORM" in
         SHELL_NAME="3rdparty-${TARGET_PLATFORM}"
         ;;
     windows-x86_64)
-        # Windows uses MSVC; the caller (build.ps1 or the CI workflow) is
-        # expected to have already loaded vcvarsall and put make + nasm on
-        # PATH. Skip nix and exec the inner build.sh directly.
-        if ! command -v cl >/dev/null 2>&1 && ! command -v cl.exe >/dev/null 2>&1; then
-            echo "error: windows-x86_64 requires MSVC cl on PATH" >&2
+        # Windows uses MSYS2 CLANG64 — no nix shell. CI: msys2/setup-msys2
+        # with msystem: CLANG64; locally: any MSYS2 shell with
+        # `MSYSTEM=CLANG64 bash -lc ...`.
+        if [ "${MSYSTEM:-}" != "CLANG64" ]; then
+            echo "error: windows-x86_64 must run inside MSYS2 CLANG64 (MSYSTEM=${MSYSTEM:-unset})" >&2
             exit 1
         fi
         exec bash "$(dirname "$0")/_build.sh" "$@"

--- a/build-tools/3rdparty/openssl-new/_build.sh
+++ b/build-tools/3rdparty/openssl-new/_build.sh
@@ -188,9 +188,16 @@ webasm)
     ;;
 
 windows-x86_64)
-    # Native MSVC — caller must have vcvarsall'd the shell.
-    CFG_TARGET="VC-WIN64A"
-    MAKE_CMD="nmake"
+    # MSYS2 CLANG64 — use openssl's mingw64 target with clang. CI:
+    # msys2/setup-msys2 with msystem: CLANG64.
+    if [ "${MSYSTEM:-}" != "CLANG64" ]; then
+        echo "error: windows-x86_64 must run inside MSYS2 CLANG64 (MSYSTEM=${MSYSTEM:-unset})" >&2
+        exit 1
+    fi
+    CFG_TARGET="mingw64"
+    export CC="clang"
+    export AR="llvm-ar"
+    export RANLIB="llvm-ranlib"
     ;;
 
 *)
@@ -226,11 +233,7 @@ for _D in lib lib64; do
 done
 cp -a "$INSTALL_DIR/include" "$STAGE/"
 
-if [ "$TARGET_PLATFORM" = "windows-x86_64" ]; then
-    _LIBS=("libssl.lib" "libcrypto.lib")
-else
-    _LIBS=("libssl.a" "libcrypto.a")
-fi
+_LIBS=("libssl.a" "libcrypto.a")
 
 for _LIB in "${_LIBS[@]}"; do
     if [ ! -f "$STAGE/lib/$_LIB" ]; then

--- a/build-tools/3rdparty/openssl-new/build.sh
+++ b/build-tools/3rdparty/openssl-new/build.sh
@@ -28,8 +28,11 @@ case "$TARGET_PLATFORM" in
         SHELL_NAME="3rdparty-${TARGET_PLATFORM}"
         ;;
     windows-x86_64)
-        if ! command -v cl >/dev/null 2>&1 && ! command -v cl.exe >/dev/null 2>&1; then
-            echo "error: windows-x86_64 requires MSVC cl on PATH" >&2
+        # Windows uses MSYS2 CLANG64 — no nix shell. CI: msys2/setup-msys2
+        # with msystem: CLANG64; locally: any MSYS2 shell with
+        # `MSYSTEM=CLANG64 bash -lc ...`.
+        if [ "${MSYSTEM:-}" != "CLANG64" ]; then
+            echo "error: windows-x86_64 must run inside MSYS2 CLANG64 (MSYSTEM=${MSYSTEM:-unset})" >&2
             exit 1
         fi
         exec bash "$(dirname "$0")/_build.sh" "$@"

--- a/build-tools/3rdparty/openssl/_build.sh
+++ b/build-tools/3rdparty/openssl/_build.sh
@@ -198,9 +198,12 @@ webasm)
     ;;
 
 windows-x86_64)
-    # Native MSVC — caller must have vcvarsall'd the shell. Use Ninja so
-    # the static lib lands at $INSTALL_DIR/lib/{ssl,crypto}.lib.
-    CMAKE_ARGS+=("-DCMAKE_SYSTEM_NAME=Windows")
+    # Native MSYS2 CLANG64 — cmake auto-detects clang/llvm-ar from
+    # /clang64/bin and builds .a static libs (mingw convention).
+    if [ "${MSYSTEM:-}" != "CLANG64" ]; then
+        echo "error: windows-x86_64 must run inside MSYS2 CLANG64 (MSYSTEM=${MSYSTEM:-unset})" >&2
+        exit 1
+    fi
     ;;
 
 *)
@@ -226,11 +229,7 @@ cmake --install "$BUILD_DIR"
 # crypto/ssl on unix-like targets, libcrypto/libssl on Windows; some
 # multi-arch hosts install to lib64/. Normalise both into lib/ in stage.
 #-----------------------------------------------------------------------------
-if [ "$TARGET_PLATFORM" = "windows-x86_64" ]; then
-    _LIBS=("libssl.lib" "libcrypto.lib")
-else
-    _LIBS=("libssl.a" "libcrypto.a")
-fi
+_LIBS=("libssl.a" "libcrypto.a")
 
 mkdir -p "$STAGE/lib"
 for _D in lib lib64; do

--- a/build-tools/3rdparty/openssl/build.sh
+++ b/build-tools/3rdparty/openssl/build.sh
@@ -28,8 +28,11 @@ case "$TARGET_PLATFORM" in
         SHELL_NAME="3rdparty-${TARGET_PLATFORM}"
         ;;
     windows-x86_64)
-        if ! command -v cl >/dev/null 2>&1 && ! command -v cl.exe >/dev/null 2>&1; then
-            echo "error: windows-x86_64 requires MSVC cl on PATH" >&2
+        # Windows uses MSYS2 CLANG64 — no nix shell. CI: msys2/setup-msys2
+        # with msystem: CLANG64; locally: any MSYS2 shell with
+        # `MSYSTEM=CLANG64 bash -lc ...`.
+        if [ "${MSYSTEM:-}" != "CLANG64" ]; then
+            echo "error: windows-x86_64 must run inside MSYS2 CLANG64 (MSYSTEM=${MSYSTEM:-unset})" >&2
             exit 1
         fi
         exec bash "$(dirname "$0")/_build.sh" "$@"


### PR DESCRIPTION
Extends the qemu MSYS2 CLANG64 approach to the four other 3rdparty libs that previously had a windows-x86_64 case targeting MSVC (with no CI runner wired up). Each lib now:

  - drops the MSVC-specific configure/build flags from _build.sh (cl/lib/nmake/-DCMAKE_SYSTEM_NAME=Windows/VC-WIN64A) and uses clang + llvm-ar + the lib's native (mingw) build path,
  - normalises the install-tree library check on libname.a,
  - has its build.sh dispatcher require MSYSTEM=CLANG64 instead of cl on PATH,
  - has a build-windows job in its workflow using msys2/setup-msys2 with msystem: CLANG64 + the package set the lib needs.

Per-lib choices:
  dav1d        meson auto-detects /clang64/bin clang; no cross/
               native file needed. Packages: clang lld meson ninja
               pkgconf nasm.
  openh264     openh264's Makefile already has an OS=mingw_nt
               platform — invoked with CC=clang AR=llvm-ar.
               Packages: clang lld nasm + msys make.
  openssl      cmake auto-detects clang; produces lib*.a.
               Packages: clang lld cmake ninja.
  openssl-new  openssl's Configure target mingw64 with CC=clang
               AR=llvm-ar RANLIB=llvm-ranlib. Packages: clang lld
               + msys make + perl (Configure is perl).

Not locally verified — only qemu was. Each lib's CI run will be the first real proof; expect at least one round of small fixups.