### PR TITLE
#341: harden ygui mixins, layout, and input semantics

### DIFF
--- a/include/yetty/ygui/widget.h
+++ b/include/yetty/ygui/widget.h
@@ -35,15 +35,32 @@ enum yetty_ygui_flex_align {
     YETTY_YGUI_ALIGN_END = 2,
     YETTY_YGUI_ALIGN_STRETCH = 3,
 };
+enum yetty_ygui_flex_align_self {
+    YETTY_YGUI_ALIGN_SELF_AUTO = 0,
+    YETTY_YGUI_ALIGN_SELF_START = 1,
+    YETTY_YGUI_ALIGN_SELF_CENTER = 2,
+    YETTY_YGUI_ALIGN_SELF_END = 3,
+    YETTY_YGUI_ALIGN_SELF_STRETCH = 4,
+};
+enum yetty_ygui_flex_wrap {
+    YETTY_YGUI_WRAP_NOWRAP = 0,
+    YETTY_YGUI_WRAP_WRAP = 1,
+};
 struct yetty_ygui_layout {
     enum yetty_ygui_flex_direction direction;
     enum yetty_ygui_flex_justify justify;
     enum yetty_ygui_flex_align align;
+    enum yetty_ygui_flex_align_self align_self;
+    enum yetty_ygui_flex_wrap wrap;
     float gap;
     float padding_top;
     float padding_right;
     float padding_bottom;
     float padding_left;
+    float margin_top;
+    float margin_right;
+    float margin_bottom;
+    float margin_left;
     float width;
     float height;
     float flex_grow;
@@ -158,12 +175,71 @@ struct yetty_ycore_void_result yetty_ygui_widget_set_bg_color(struct yetty_yclas
 struct yetty_ycore_uint32_result yetty_ygui_widget_bg(const struct yetty_yclass_object *obj);
 struct yetty_ycore_void_result yetty_ygui_widget_apply_css(struct yetty_yclass_object *obj,
                                                            const char *css);
+/*
+ * Generic "call the parent's implementation of this slot" helpers.
+ *
+ * ABI CONTRACT: read before adding a new caller. These two generic helpers
+ * cast the resolved parent impl to a function pointer that takes only:
+ *
+ *     (struct yetty_yclass_object *)
+ *
+ * They are therefore valid only for slots whose implementation signature is
+ * exactly that. In the current ygui widget slot set, that means constructor
+ * and destructor for super_void.
+ *
+ * They must not be used for slots that carry extra parameters. In particular,
+ * these widget slots have wider signatures:
+ *
+ *     widget_on_press(obj, float x, float y, int button)
+ *     widget_on_release(obj, float x, float y, int button)
+ *     widget_on_motion(obj, float x, float y)
+ *     widget_on_scroll(obj, float x, float y, float dx, float dy)
+ *     widget_paint(obj, struct yetty_ygui_emit_ctx *)
+ *     widget_emit_container(obj, struct yetty_ygui_emit_ctx *)
+ *     widget_emit_body(obj, struct yetty_ygui_emit_ctx *)
+ *
+ * Routing one of those through super_void/super_int casts away the extra
+ * arguments and calls with the wrong ABI (undefined behavior). If a subclass
+ * needs to chain to a parent implementation for a wider slot, add a typed
+ * per-slot super helper with the matching signature rather than widening
+ * these generic helpers.
+ *
+ * This contract is ENFORCED at runtime, not merely documented: super_void
+ * rejects any method_id other than constructor/destructor, and super_int —
+ * for which no valid (obj)-only int virtual exists and which has no callers —
+ * rejects unconditionally. Both return a Result error rather than performing
+ * the unsafe cast, so misuse fails loudly at the call site.
+ */
 struct yetty_ycore_void_result yetty_ygui_super_void(struct yetty_yclass_object *obj,
                                                      const struct yetty_yclass *self_class,
                                                      yetty_yclass_method_id_t method_id);
 struct yetty_ycore_int_result yetty_ygui_super_int(struct yetty_yclass_object *obj,
                                                    const struct yetty_yclass *self_class,
                                                    yetty_yclass_method_id_t method_id);
+struct yetty_ycore_int_result yetty_ygui_super_on_press(struct yetty_yclass_object *obj,
+                                                        const struct yetty_yclass *self_class,
+                                                        float x, float y, int button);
+struct yetty_ycore_int_result yetty_ygui_super_on_release(struct yetty_yclass_object *obj,
+                                                          const struct yetty_yclass *self_class,
+                                                          float x, float y, int button);
+struct yetty_ycore_int_result yetty_ygui_super_on_motion(struct yetty_yclass_object *obj,
+                                                         const struct yetty_yclass *self_class,
+                                                         float x, float y);
+struct yetty_ycore_int_result yetty_ygui_super_on_scroll(struct yetty_yclass_object *obj,
+                                                         const struct yetty_yclass *self_class,
+                                                         float x, float y, float dx, float dy);
+struct yetty_ycore_int_result yetty_ygui_mixin_on_press(struct yetty_yclass_object *obj,
+                                                        const struct yetty_yclass *mixin_class,
+                                                        float x, float y, int button);
+struct yetty_ycore_int_result yetty_ygui_mixin_on_release(struct yetty_yclass_object *obj,
+                                                          const struct yetty_yclass *mixin_class,
+                                                          float x, float y, int button);
+struct yetty_ycore_int_result yetty_ygui_mixin_on_motion(struct yetty_yclass_object *obj,
+                                                         const struct yetty_yclass *mixin_class,
+                                                         float x, float y);
+struct yetty_ycore_int_result yetty_ygui_mixin_on_scroll(struct yetty_yclass_object *obj,
+                                                         const struct yetty_yclass *mixin_class,
+                                                         float x, float y, float dx, float dy);
 const struct yetty_yclass *yetty_ygui_class_expect(struct yetty_yclass_ptr_result class_result,
                                                    const char *name);
 struct yetty_yclass_object_ptr_result yetty_ygui_widget_parent(struct yetty_yclass_object *obj);

--- a/src/yetty/yclass/README.md
+++ b/src/yetty/yclass/README.md
@@ -91,6 +91,18 @@ boundaries. Registration and lookup are uthash-backed (O(1) on hit); the server
 side installs lazy "accessor lookups" so it can resolve classes it has never
 touched.
 
+**Mixin dispatch is flat, not compositional.** At registration the dispatch
+table is filled in the order **parent → mixins (declaration order) → leaf
+ops**, and each stage *overwrites* any slot the previous stage set. So a mixin
+provides a data slice plus **default** slot implementations: a mixin slot
+replaces the parent's, a later mixin replaces an earlier one, and the leaf's own
+op replaces whatever a mixin left. There is **no automatic chaining** — a mixin
+cannot wrap the slot it shadows, and a leaf override does not implicitly run the
+mixin's version. `super` walks only the **parent** chain, never the mixin list,
+so "call the mixin part" is not expressible through it; if two behaviors must
+genuinely compose, invoke them explicitly. Model a mixin as a default-behavior
+provider, not a trait that layers onto what is already there.
+
 ### Local vs remote — the same call
 
 A method slot takes the object first — there is no `ctx` argument:

--- a/src/yetty/yclass/class.c
+++ b/src/yetty/yclass/class.c
@@ -444,6 +444,19 @@ static struct yetty_ycore_void_result dispatch_slice_grow(struct dispatch_slice 
     return YETTY_OK_VOID();
 }
 
+/*
+ * Copy every slot `src` implements into `cls`'s dispatch table, overwriting
+ * on collision. This is a flat vtable copy, not a compositional merge.
+ *
+ * Registration applies dispatch in this order:
+ *
+ *     parent -> mixins (in declaration order) -> leaf ops
+ *
+ * Each stage overwrites the previous one for any slot it implements. A mixin
+ * therefore provides a data slice plus default slot implementations; it does
+ * not automatically wrap or chain behavior from the parent, from earlier
+ * mixins, or from the leaf.
+ */
 static struct yetty_ycore_void_result class_inherit_dispatch(struct yetty_yclass *cls,
                                                              const struct yetty_yclass *src)
 {

--- a/src/yetty/yclass/gen/codegen.py
+++ b/src/yetty/yclass/gen/codegen.py
@@ -766,6 +766,16 @@ def parse_sources(include_dirs: list, sources: list, module: str) -> dict:
     # definition seen across the parsed TUs, keyed by tag.
     record_reg: dict = {}
     enum_reg: dict = {}
+    # Authoritative struct/enum bodies harvested from the module .c that DEFINES
+    # each type (has a body, decl_file == the .c). `_collect_type_decls` fills
+    # record_reg/enum_reg last-write-wins across every parsed TU, so a sibling
+    # source that #includes the (possibly stale) generated header would clobber
+    # the freshly-edited definition — freezing the reproduced type at its
+    # pre-edit shape and making the generated header impossible to update. These
+    # are re-applied over record_reg/enum_reg after all TUs parse so the owning
+    # .c always wins, regardless of parse order or header staleness.
+    authoritative_records: dict = {}
+    authoritative_enums: dict = {}
     # Tag -> the module .c that DEFINES it (has a body). Only types authored
     # in the module's own sources are safe to reproduce as a full definition
     # in a generated header; types from #include'd third-party/ycore headers
@@ -857,10 +867,17 @@ def parse_sources(include_dirs: list, sources: list, module: str) -> dict:
             # `expose` annotation.
             if decl_file == str(path) and decl.get("name"):
                 if kind in ("RecordDecl", "EnumDecl"):
-                    has_body = (bool(_record_field_list(decl)) if kind == "RecordDecl"
-                                else bool(_enum_values(decl)))
+                    record_body = _record_field_list(decl) if kind == "RecordDecl" else None
+                    enum_body = _enum_values(decl) if kind == "EnumDecl" else None
+                    has_body = bool(record_body) if kind == "RecordDecl" else bool(enum_body)
                     if has_body:
                         local_type_files.setdefault(decl["name"], str(path))
+                        # This .c owns the type — record its own body so it can
+                        # be re-asserted over any stale header copy after parse.
+                        if kind == "RecordDecl":
+                            authoritative_records[decl["name"]] = record_body
+                        else:
+                            authoritative_enums[decl["name"]] = enum_body
                 elif kind == "TypedefDecl":
                     local_typedefs.setdefault(
                         decl["name"],
@@ -1208,6 +1225,13 @@ def parse_sources(include_dirs: list, sources: list, module: str) -> dict:
     # `exposed: []` out of every other module's model.yaml.
     if exposed:
         model["exposed"] = exposed
+    # Re-assert every type authored in this module's own .c over whatever a
+    # sibling TU last wrote into the registries via an #include of the (possibly
+    # stale) generated header. Without this, editing a reproduced struct/enum
+    # never propagates: the pre-edit shape pulled in through the header wins by
+    # parse order and the generated header can't converge on the new definition.
+    record_reg.update(authoritative_records)
+    enum_reg.update(authoritative_enums)
     # Concrete layouts for by-value struct/enum types referenced by the
     # module's signatures (Result family, POD structs, enums) — transitively
     # resolved so the FFI generator is fully model-driven.

--- a/src/yetty/ygui/framework.c
+++ b/src/yetty/ygui/framework.c
@@ -849,7 +849,19 @@ static int rect_contains(struct yetty_ycore_rectangle r, float x, float y)
 
 /* Returns the deepest descendant of `node` whose rect contains (x, y),
  * or NULL if no descendant matches. Children later in sibling order
- * win over earlier ones (paint order — last-drawn is on top). */
+ * win over earlier ones (paint order — last-drawn is on top).
+ *
+ * Figure/scrollarea clipping is already enforced here WITHOUT a separate
+ * scissor parameter: the recursion prunes the whole subtree the moment the
+ * point falls outside a node's rect, so reaching a descendant requires the
+ * point to lie inside EVERY ancestor's rect. The emit walk's fig_clip is the
+ * intersection of the figure ancestors' rects (a subset of all ancestors),
+ * so it can only be looser than the per-ancestor test applied here. A point
+ * this walk accepts is therefore always inside fig_clip — a scrollarea child
+ * scrolled out of the viewport has its rect moved outside the scrollarea's
+ * rect (the layout pass bakes scroll_main into child rects) and is rejected
+ * at the scrollarea node. No off-viewport child is ever hittable; threading
+ * an explicit clip rect through here would be dead code. */
 static struct yetty_yclass_object_ptr_result hit_test(struct yetty_yclass_object *node, float x,
                                                       float y)
 {

--- a/src/yetty/ygui/layout.c
+++ b/src/yetty/ygui/layout.c
@@ -1,34 +1,36 @@
 /*
  * ygui-layout.c — flex layout pass for the new toolkit.
  *
- * Algorithm summary:
+ * This is a compact but genuinely CSS-flexbox-shaped engine (not the earlier
+ * "single-line only" reduction). Per container it:
  *
- *   For each container:
- *     1. Compute its content box (rect minus padding).
- *     2. Walk in-flow children:
- *        - "main size" = layout.width (row) or layout.height (column)
- *          clamped to [min, max]. Unset (-1.0f) treated as 0 baseline,
- *          flex_grow >0 then distributes free space.
- *        - "cross size" = layout.height (row) or layout.width (column),
- *          clamped. Unset means "auto" — uses parent cross-content for
- *          align=stretch, else 0 baseline.
- *     3. Sum children base sizes + gaps; free_space = content_main - sum.
- *        Distribute free_space proportionally to flex_grow / flex_shrink.
- *     4. Position children main-axis according to justify_content.
- *     5. Position children cross-axis according to align (parent default)
- *        / align (per-child override is not yet supported in this port —
- *        per-child align lives in a follow-up).
- *     6. Recurse into each child.
+ *   1. Computes the content box (rect minus padding).
+ *   2. Resolves each in-flow child's flex base + cross size, its per-side
+ *      margins, and its align-self.
+ *   3. Breaks children into lines: one line for wrap == NOWRAP, or as many as
+ *      needed for wrap == WRAP (a child that would overflow the main axis
+ *      starts a new line).
+ *   4. Per line, resolves flexible main sizes with the CSS "resolve flexible
+ *      lengths" freeze loop — grow distributes spare space by flex_grow,
+ *      shrink removes overflow weighted by flex_shrink * flex_basis, and a
+ *      child that hits its min/max is frozen and the remaining space is
+ *      redistributed to its still-flexible siblings.
+ *   5. Positions each line's children on the main axis by justify_content and
+ *      on the cross axis by align-self (falling back to the parent's align),
+ *      honouring margins and the container's scroll offset.
+ *   6. Stacks lines on the cross axis (wrap), then recurses into each child.
  *
- * Restricted feature set (current port):
- *   - No wrap (single-line flex).
- *   - No absolute positioning (every child is in-flow).
- *   - No percent sizing (px only).
- *   - No baseline alignment.
- *   - No margins on widgets (use padding on the parent + gap instead).
+ * Supported: flex-direction (row/column), justify (start/center/end/
+ * space-between), align + per-child align-self (start/center/end/stretch),
+ * flex-grow, flex-shrink (basis-weighted), min/max with redistribution,
+ * per-side margins, gap, wrap, absolute positioning (a child with
+ * layout.absolute is placed at pos_x/pos_y in the content box and skips flex),
+ * and an intrinsic content-measure pass that sizes non-grow containers from
+ * their children.
  *
- * These are intentional simplifications — the new toolkit will grow
- * each feature back in as widgets need them.
+ * Still intentionally out of scope: percent sizing (px only), baseline
+ * alignment, align-content (wrap lines pack toward the cross start), and
+ * writing-mode/RTL (main/cross leading = top/left).
  */
 
 #include "internal.h"
@@ -65,8 +67,9 @@ static struct yetty_ycore_void_result layout_node(struct yetty_yclass_object *no
  * sensible preferred main-axis size when its own width/height is unset
  * (-1). A leaf (no in-flow children) measures 0 on an unset axis; a
  * container measures padding + the sum of its visible in-flow children's
- * sizes along its own direction (+ gaps), and the max child size on the
- * cross axis. Recurses so nested vbox/tree_node stacks size bottom-up.
+ * sizes along its own direction (+ gaps + the children's main-axis margins),
+ * and the max child size (+ cross margins) on the cross axis. Recurses so
+ * nested vbox/tree_node stacks size bottom-up.
  *
  * Authored sizes (>= 0) always win; only unset axes are derived. */
 static struct yetty_ycore_void_result measure_size(struct yetty_yclass_object *node, float *out_w,
@@ -97,8 +100,10 @@ static struct yetty_ycore_void_result measure_size(struct yetty_yclass_object *n
                 float cw = 0.0f, ch = 0.0f;
                 struct yetty_ycore_void_result m_res = measure_size(c, &cw, &ch);
                 YETTY_RETURN_IF_ERR(yetty_ycore_void, m_res, "measure_size: child measure");
-                float cmain = row ? cw : ch;
-                float ccross = row ? ch : cw;
+                float margin_w = cl->margin_left + cl->margin_right;
+                float margin_h = cl->margin_top + cl->margin_bottom;
+                float cmain = (row ? cw + margin_w : ch + margin_h);
+                float ccross = (row ? ch + margin_h : cw + margin_w);
                 main_sum += cmain;
                 if (ccross > cross_max) {
                     cross_max = ccross;
@@ -132,100 +137,320 @@ static struct yetty_ycore_void_result measure_size(struct yetty_yclass_object *n
     return YETTY_OK_VOID();
 }
 
-/* Resolve a child's preferred main-axis size + cross-axis size into the
- * given container, before flex grow/shrink distribution. */
-struct child_axes {
-    float main_pref;
-    float cross_pref;
+/* One in-flow child resolved into the parent's main/cross frame. Margins and
+ * align-self are pre-projected onto the main/cross axes so the placement code
+ * is direction-agnostic. `main_size`/`cross_size` are filled by the sizing
+ * pass. */
+struct flex_item {
+    struct yetty_yclass_object *child;
+    float base_main;
     float main_min;
     float main_max;
+    float cross_base; /* authored cross size, 0 = auto */
     float cross_min;
     float cross_max;
     float grow;
     float shrink;
+    float margin_main_lead;
+    float margin_main_trail;
+    float margin_cross_lead;
+    float margin_cross_trail;
+    enum yetty_ygui_flex_align_self align_self;
+    float main_size;
+    float cross_size;
 };
 
-YETTY_YRESULT_DECLARE(child_axes, struct child_axes);
+YETTY_YRESULT_DECLARE(flex_item, struct flex_item);
 
-static struct child_axes_result resolve_child_axes(const struct yetty_ygui_layout *parent_layout,
-                                                   struct yetty_yclass_object *child)
+static struct flex_item_result resolve_flex_item(const struct yetty_ygui_layout *parent_layout,
+                                                 struct yetty_yclass_object *child)
 {
     struct yetty_ygui_layout_const_ptr_result child_layout_res =
         yetty_ygui_widget_layout_get(child);
-    YETTY_RETURN_IF_ERR(child_axes, child_layout_res, "resolve_child_axes: layout_get");
-    const struct yetty_ygui_layout *child_layout = child_layout_res.value;
-    struct child_axes a;
+    YETTY_RETURN_IF_ERR(flex_item, child_layout_res, "resolve_flex_item: layout_get");
+    const struct yetty_ygui_layout *cl = child_layout_res.value;
+    struct flex_item item = {0};
+    item.child = child;
     int row = direction_is_row(parent_layout);
-    float authored_main = row ? child_layout->width : child_layout->height;
+    float authored_main = row ? cl->width : cl->height;
     if (row) {
-        a.main_pref = child_layout->width >= 0.0f ? child_layout->width : 0.0f;
-        a.cross_pref = child_layout->height >= 0.0f ? child_layout->height : 0.0f;
-        a.main_min = child_layout->min_width;
-        a.main_max = child_layout->max_width;
-        a.cross_min = child_layout->min_height;
-        a.cross_max = child_layout->max_height;
+        item.base_main = cl->width >= 0.0f ? cl->width : 0.0f;
+        item.cross_base = cl->height >= 0.0f ? cl->height : 0.0f;
+        item.main_min = cl->min_width;
+        item.main_max = cl->max_width;
+        item.cross_min = cl->min_height;
+        item.cross_max = cl->max_height;
+        item.margin_main_lead = cl->margin_left;
+        item.margin_main_trail = cl->margin_right;
+        item.margin_cross_lead = cl->margin_top;
+        item.margin_cross_trail = cl->margin_bottom;
     } else {
-        a.main_pref = child_layout->height >= 0.0f ? child_layout->height : 0.0f;
-        a.cross_pref = child_layout->width >= 0.0f ? child_layout->width : 0.0f;
-        a.main_min = child_layout->min_height;
-        a.main_max = child_layout->max_height;
-        a.cross_min = child_layout->min_width;
-        a.cross_max = child_layout->max_width;
+        item.base_main = cl->height >= 0.0f ? cl->height : 0.0f;
+        item.cross_base = cl->width >= 0.0f ? cl->width : 0.0f;
+        item.main_min = cl->min_height;
+        item.main_max = cl->max_height;
+        item.cross_min = cl->min_width;
+        item.cross_max = cl->max_width;
+        item.margin_main_lead = cl->margin_top;
+        item.margin_main_trail = cl->margin_bottom;
+        item.margin_cross_lead = cl->margin_left;
+        item.margin_cross_trail = cl->margin_right;
     }
-    a.grow = child_layout->flex_grow;
-    a.shrink = child_layout->flex_shrink;
+    item.grow = cl->flex_grow;
+    item.shrink = cl->flex_shrink;
+    item.align_self = cl->align_self;
     /* When the child doesn't author its main size and won't grow to fill,
      * derive an intrinsic content size so nested containers (tree_node,
-     * vbox-of-rows) stack instead of collapsing to a zero rect. Grow
-     * children keep a 0 base — they expand to fill regardless. Childless
-     * leaves measure 0 (unless they carry padding, e.g. a tree_node whose
-     * header lives in padding_top), so this is safe for plain widgets. */
-    if (authored_main < 0.0f && a.grow <= 0.0f) {
+     * vbox-of-rows) stack instead of collapsing to a zero rect. Grow children
+     * keep a 0 base — they expand to fill regardless. */
+    if (authored_main < 0.0f && item.grow <= 0.0f) {
         float mw = 0.0f, mh = 0.0f;
         struct yetty_ycore_void_result m_res = measure_size(child, &mw, &mh);
-        YETTY_RETURN_IF_ERR(child_axes, m_res, "resolve_child_axes: measure_size");
-        a.main_pref = row ? mw : mh;
+        YETTY_RETURN_IF_ERR(flex_item, m_res, "resolve_flex_item: measure_size");
+        item.base_main = row ? mw : mh;
     }
-    a.main_pref = clamp_size(a.main_pref, a.main_min, a.main_max);
-    return YETTY_OK(child_axes, a);
+    item.base_main = clamp_size(item.base_main, item.main_min, item.main_max);
+    return YETTY_OK(flex_item, item);
 }
 
-/* Count visible in-flow children + sum their preferred main sizes +
- * flex factors. */
-struct flex_summary {
-    int child_count;
-    float sum_main_pref;
-    float sum_grow;
-    float sum_shrink;
-};
-
-YETTY_YRESULT_DECLARE(flex_summary, struct flex_summary);
-
-static struct flex_summary_result summarize_children(struct yetty_yclass_object *parent,
-                                                     const struct yetty_ygui_layout *parent_layout)
+/* CSS "resolve flexible lengths" for one line: fill each item's `main_size`,
+ * distributing `content_main` minus the line's margins and gaps by flex_grow
+ * (spare space) or flex_shrink * flex_basis (overflow). A child clamped to its
+ * min/max is frozen and its surplus/deficit flows to the still-flexible
+ * siblings on the next pass, so min/max no longer silently strand space. */
+static void resolve_line_main(struct flex_item *items, int start, int count, float content_main,
+                              float gap)
 {
-    struct flex_summary s = {0};
-    struct yetty_yclass_object_ptr_result child_res = yetty_ygui_widget_first_child(parent);
-    YETTY_RETURN_IF_ERR(flex_summary, child_res, "summarize_children: first_child");
-    for (struct yetty_yclass_object *c = child_res.value; c;) {
-        struct yetty_ygui_layout_const_ptr_result child_layout_res =
-            yetty_ygui_widget_layout_get(c);
-        YETTY_RETURN_IF_ERR(flex_summary, child_layout_res, "summarize_children: layout_get");
-        const struct yetty_ygui_layout *cl = child_layout_res.value;
-        /* Hidden subtrees and absolutely-positioned children skip flex. */
-        if (!cl->hidden && !cl->absolute) {
-            struct child_axes_result axes_res = resolve_child_axes(parent_layout, c);
-            YETTY_RETURN_IF_ERR(flex_summary, axes_res, "summarize_children: resolve_child_axes");
-            s.child_count++;
-            s.sum_main_pref += axes_res.value.main_pref;
-            s.sum_grow += axes_res.value.grow;
-            s.sum_shrink += axes_res.value.shrink;
-        }
-        struct yetty_yclass_object_ptr_result next_res = yetty_ygui_widget_next_sibling(c);
-        YETTY_RETURN_IF_ERR(flex_summary, next_res, "summarize_children: next_sibling");
-        c = next_res.value;
+    if (count <= 0) {
+        return;
     }
-    return YETTY_OK(flex_summary, s);
+    float sum_base = 0.0f;
+    float sum_margin = 0.0f;
+    for (int i = 0; i < count; ++i) {
+        struct flex_item *it = &items[start + i];
+        sum_base += it->base_main;
+        sum_margin += it->margin_main_lead + it->margin_main_trail;
+        it->main_size = it->base_main; /* frozen items keep this */
+    }
+    float total_gap = count > 1 ? gap * (float)(count - 1) : 0.0f;
+    float space = content_main - sum_margin - total_gap;
+    int growing = (space - sum_base) >= 0.0f;
+
+    /* frozen[] lives in main_size once frozen; track with a parallel flag via
+     * a small heap array only when needed. count is tiny (siblings), so a
+     * stack VLA-free bounded loop over a calloc'd flag array is simplest. */
+    int *frozen = calloc((size_t)count, sizeof(*frozen));
+    if (!frozen) {
+        /* Out of memory on a per-line flag array: fall back to unflexed base
+         * sizes (already stored in main_size) rather than fail the layout. */
+        return;
+    }
+    for (int i = 0; i < count; ++i) {
+        struct flex_item *it = &items[start + i];
+        float factor = growing ? it->grow : it->shrink;
+        if (factor <= 0.0f) {
+            frozen[i] = 1;
+            it->main_size = clamp_size(it->base_main, it->main_min, it->main_max);
+        }
+    }
+    for (int pass = 0; pass < count; ++pass) {
+        float used = 0.0f;
+        float sum_factor = 0.0f;
+        for (int i = 0; i < count; ++i) {
+            struct flex_item *it = &items[start + i];
+            if (frozen[i]) {
+                used += it->main_size;
+            } else {
+                used += it->base_main;
+                sum_factor += growing ? it->grow : it->shrink * it->base_main;
+            }
+        }
+        if (sum_factor <= 0.0f) {
+            break;
+        }
+        float free_main = space - used;
+        int newly_frozen = 0;
+        for (int i = 0; i < count; ++i) {
+            struct flex_item *it = &items[start + i];
+            if (frozen[i]) {
+                continue;
+            }
+            float weight = growing ? it->grow : it->shrink * it->base_main;
+            float target = it->base_main + free_main * (weight / sum_factor);
+            float clamped = clamp_size(target, it->main_min, it->main_max);
+            it->main_size = clamped;
+            if (clamped != target) {
+                frozen[i] = 1;
+                newly_frozen = 1;
+            }
+        }
+        if (!newly_frozen) {
+            break;
+        }
+    }
+    free(frozen);
+}
+
+/* Cross size of an item within a line of extent `line_cross`, honouring
+ * align-self (falling back to the parent align) and the item's cross margins.
+ * Only an auto (unauthored) cross size stretches. */
+static float item_cross_size(const struct flex_item *it, enum yetty_ygui_flex_align parent_align,
+                             float line_cross)
+{
+    enum yetty_ygui_flex_align eff = parent_align;
+    switch (it->align_self) {
+    case YETTY_YGUI_ALIGN_SELF_START:
+        eff = YETTY_YGUI_ALIGN_START;
+        break;
+    case YETTY_YGUI_ALIGN_SELF_CENTER:
+        eff = YETTY_YGUI_ALIGN_CENTER;
+        break;
+    case YETTY_YGUI_ALIGN_SELF_END:
+        eff = YETTY_YGUI_ALIGN_END;
+        break;
+    case YETTY_YGUI_ALIGN_SELF_STRETCH:
+        eff = YETTY_YGUI_ALIGN_STRETCH;
+        break;
+    case YETTY_YGUI_ALIGN_SELF_AUTO:
+    default:
+        break;
+    }
+    float cross;
+    if (eff == YETTY_YGUI_ALIGN_STRETCH && it->cross_base == 0.0f) {
+        cross = line_cross - it->margin_cross_lead - it->margin_cross_trail;
+    } else {
+        cross = it->cross_base;
+    }
+    return clamp_size(cross, it->cross_min, it->cross_max);
+}
+
+/* Cross-axis offset of an item's border box inside a line of extent
+ * `line_cross` starting at `line_start` (already inside the content box). */
+static float item_cross_offset(const struct flex_item *it, enum yetty_ygui_flex_align parent_align,
+                               float line_start, float line_cross, float cross_size)
+{
+    enum yetty_ygui_flex_align eff = parent_align;
+    switch (it->align_self) {
+    case YETTY_YGUI_ALIGN_SELF_START:
+        eff = YETTY_YGUI_ALIGN_START;
+        break;
+    case YETTY_YGUI_ALIGN_SELF_CENTER:
+        eff = YETTY_YGUI_ALIGN_CENTER;
+        break;
+    case YETTY_YGUI_ALIGN_SELF_END:
+        eff = YETTY_YGUI_ALIGN_END;
+        break;
+    case YETTY_YGUI_ALIGN_SELF_STRETCH:
+        eff = YETTY_YGUI_ALIGN_STRETCH;
+        break;
+    case YETTY_YGUI_ALIGN_SELF_AUTO:
+    default:
+        break;
+    }
+    switch (eff) {
+    case YETTY_YGUI_ALIGN_CENTER:
+        /* Center the border box within the margin box: consume the leading
+         * margin, then split the remaining cross space. Reduces to the plain
+         * midpoint when both cross margins are 0. */
+        return line_start + it->margin_cross_lead +
+               (line_cross - it->margin_cross_lead - cross_size - it->margin_cross_trail) * 0.5f;
+    case YETTY_YGUI_ALIGN_END:
+        return line_start + line_cross - cross_size - it->margin_cross_trail;
+    case YETTY_YGUI_ALIGN_STRETCH:
+    case YETTY_YGUI_ALIGN_START:
+    default:
+        return line_start + it->margin_cross_lead;
+    }
+}
+
+/* Place one resolved line's children. `line_cross_start` is the cross-axis
+ * origin of the line inside the content box; `line_cross` its extent. Recurses
+ * into each child. */
+static struct yetty_ycore_void_result place_line(struct flex_item *items, int start, int count,
+                                                 const struct yetty_ygui_layout *pl,
+                                                 float content_min_x, float content_min_y,
+                                                 float content_main, float gap, float scroll,
+                                                 float line_cross_start, float line_cross)
+{
+    int row = direction_is_row(pl);
+    float sum_main = 0.0f;
+    float sum_margin = 0.0f;
+    for (int i = 0; i < count; ++i) {
+        sum_main += items[start + i].main_size;
+        sum_margin += items[start + i].margin_main_lead + items[start + i].margin_main_trail;
+    }
+    float total_gap = count > 1 ? gap * (float)(count - 1) : 0.0f;
+    float leftover = content_main - sum_main - sum_margin - total_gap;
+
+    float main_offset = 0.0f;
+    float gap_between = gap;
+    if (leftover > 0.0f) {
+        switch (pl->justify) {
+        case YETTY_YGUI_JUSTIFY_CENTER:
+            main_offset = leftover * 0.5f;
+            break;
+        case YETTY_YGUI_JUSTIFY_END:
+            main_offset = leftover;
+            break;
+        case YETTY_YGUI_JUSTIFY_SPACE_BETWEEN:
+            if (count > 1) {
+                gap_between += leftover / (float)(count - 1);
+            }
+            break;
+        case YETTY_YGUI_JUSTIFY_START:
+        default:
+            break;
+        }
+    }
+
+    float cursor_main = main_offset - scroll;
+    for (int i = 0; i < count; ++i) {
+        struct flex_item *it = &items[start + i];
+        float cross_size = item_cross_size(it, pl->align, line_cross);
+        float cross_off =
+            item_cross_offset(it, pl->align, line_cross_start, line_cross, cross_size);
+        cursor_main += it->margin_main_lead;
+
+        struct yetty_ycore_rectangle crect;
+        if (row) {
+            crect.min.x = content_min_x + cursor_main;
+            crect.min.y = content_min_y + cross_off;
+            crect.max.x = crect.min.x + it->main_size;
+            crect.max.y = crect.min.y + cross_size;
+        } else {
+            crect.min.x = content_min_x + cross_off;
+            crect.min.y = content_min_y + cursor_main;
+            crect.max.x = crect.min.x + cross_size;
+            crect.max.y = crect.min.y + it->main_size;
+        }
+        struct yetty_ycore_void_result r = layout_node(it->child, crect);
+        YETTY_RETURN_IF_ERR(yetty_ycore_void, r, "place_line: child");
+
+        cursor_main += it->main_size + it->margin_main_trail + gap_between;
+    }
+    return YETTY_OK_VOID();
+}
+
+/* Resolve, cross-size and place one wrap line [start, start+count), returning
+ * the line's cross extent so the caller can advance to the next line. */
+static struct yetty_ycore_void_result flush_wrap_line(struct flex_item *items, int start, int count,
+                                                      const struct yetty_ygui_layout *pl,
+                                                      float content_min_x, float content_min_y,
+                                                      float content_main, float scroll,
+                                                      float cross_cursor, float *out_line_cross)
+{
+    resolve_line_main(items, start, count, content_main, pl->gap);
+    float line_cross = 0.0f;
+    for (int k = start; k < start + count; ++k) {
+        float ch = item_cross_size(&items[k], pl->align, 0.0f) + items[k].margin_cross_lead +
+                   items[k].margin_cross_trail;
+        if (ch > line_cross) {
+            line_cross = ch;
+        }
+    }
+    *out_line_cross = line_cross;
+    return place_line(items, start, count, pl, content_min_x, content_min_y, content_main, pl->gap,
+                      scroll, cross_cursor, line_cross);
 }
 
 static struct yetty_ycore_void_result layout_node(struct yetty_yclass_object *node,
@@ -262,65 +487,35 @@ static struct yetty_ycore_void_result layout_node(struct yetty_yclass_object *no
 
     float content_w = content_max_x - content_min_x;
     float content_h = content_max_y - content_min_y;
-    float content_main = direction_is_row(pl) ? content_w : content_h;
-    float content_cross = direction_is_row(pl) ? content_h : content_w;
+    int row = direction_is_row(pl);
+    float content_main = row ? content_w : content_h;
+    float content_cross = row ? content_h : content_w;
 
-    struct flex_summary_result sum_res = summarize_children(node, pl);
-    YETTY_RETURN_IF_ERR(yetty_ycore_void, sum_res, "layout_node: summarize_children");
-    struct flex_summary sum = sum_res.value;
-    /* Total gap consumed between flex children (zero when no flex children
-     * exist). Absolute children still need to be placed, so this function
-     * cannot early-return on `child_count == 0`. */
-    float total_gap = sum.child_count > 1 ? pl->gap * (float)(sum.child_count - 1) : 0.0f;
-    float consumed = sum.sum_main_pref + total_gap;
-    float free_space = content_main - consumed;
+    struct yetty_ycore_float_result scroll_res = yetty_ygui_widget_scroll_main_get(node);
+    YETTY_RETURN_IF_ERR(yetty_ycore_void, scroll_res, "layout_node: scroll_main_get");
+    float scroll = scroll_res.value;
 
-    /* Distribute free_space via grow if positive, shrink if negative. */
-    float grow_unit = 0.0f, shrink_unit = 0.0f;
-    if (free_space > 0.0f && sum.sum_grow > 0.0f) {
-        grow_unit = free_space / sum.sum_grow;
-    } else if (free_space < 0.0f && sum.sum_shrink > 0.0f) {
-        shrink_unit = free_space / sum.sum_shrink;
-    }
-
-    /* Two-pass: first compute sizes, then place using justify. The size
-     * arrays are allocated for the actual flex-child count; absolute
-     * children are sized inline above and skipped here. */
-    float total_main = 0.0f;
-    int idx = 0;
-    float *main_sizes = NULL;
-    float *cross_sizes = NULL;
-    if (sum.child_count > 0) {
-        main_sizes = calloc((size_t)sum.child_count, sizeof(*main_sizes));
-        cross_sizes = calloc((size_t)sum.child_count, sizeof(*cross_sizes));
-        if (!main_sizes || !cross_sizes) {
-            free(main_sizes);
-            free(cross_sizes);
-            return YETTY_ERR(yetty_ycore_void, "layout_node: alloc sizes");
-        }
-    }
-
+    /* Count children so the item array is sized once; also place absolute
+     * children (they skip flex bookkeeping entirely). */
+    int child_total = 0;
     struct yetty_ycore_void_result loop_r = YETTY_OK_VOID();
     {
         struct yetty_yclass_object_ptr_result iter_res = yetty_ygui_widget_first_child(node);
-        if (YETTY_IS_ERR(iter_res)) {
-            loop_r = YETTY_ERR(yetty_ycore_void, "layout_node: first_child", iter_res);
-            goto cleanup;
-        }
+        YETTY_RETURN_IF_ERR(yetty_ycore_void, iter_res, "layout_node: count first_child");
         for (struct yetty_yclass_object *c = iter_res.value; c;) {
             struct yetty_ygui_layout_const_ptr_result child_layout_res =
                 yetty_ygui_widget_layout_get(c);
-            if (YETTY_IS_ERR(child_layout_res)) {
-                loop_r =
-                    YETTY_ERR(yetty_ycore_void, "layout_node: child layout_get", child_layout_res);
-                goto cleanup;
-            }
+            YETTY_RETURN_IF_ERR(yetty_ycore_void, child_layout_res,
+                                "layout_node: count layout_get");
             const struct yetty_ygui_layout *cl = child_layout_res.value;
+            /* Order matters: a hidden child is skipped entirely — no rect, no
+             * recurse — even when it is also absolute, so a folded-away
+             * positioned overlay keeps its stale geometry and never lays out
+             * its subtree. (Checking absolute first would place hidden+absolute
+             * children, the regression this order avoids.) */
             if (cl->hidden) {
-                /* folded away — no rect, no recurse */
+                /* folded away */
             } else if (cl->absolute) {
-                /* Place absolute children directly at (pos_x, pos_y) inside
-                 * parent content box. Skip flex bookkeeping. */
                 struct yetty_ycore_rectangle crect;
                 float aw = cl->width >= 0.0f ? cl->width : 0.0f;
                 float ah = cl->height >= 0.0f ? cl->height : 0.0f;
@@ -328,161 +523,109 @@ static struct yetty_ycore_void_result layout_node(struct yetty_yclass_object *no
                 crect.min.y = content_min_y + cl->pos_y;
                 crect.max.x = crect.min.x + aw;
                 crect.max.y = crect.min.y + ah;
-                loop_r = layout_node(c, crect);
-                if (YETTY_IS_ERR(loop_r)) {
-                    goto cleanup;
-                }
+                struct yetty_ycore_void_result r = layout_node(c, crect);
+                YETTY_RETURN_IF_ERR(yetty_ycore_void, r, "layout_node: absolute child");
             } else {
-                struct child_axes_result axes_res = resolve_child_axes(pl, c);
-                if (YETTY_IS_ERR(axes_res)) {
-                    loop_r =
-                        YETTY_ERR(yetty_ycore_void, "layout_node: resolve_child_axes", axes_res);
-                    goto cleanup;
-                }
-                struct child_axes a = axes_res.value;
-                float ms = a.main_pref;
-                if (grow_unit > 0.0f) {
-                    ms += a.grow * grow_unit;
-                } else if (shrink_unit < 0.0f) {
-                    ms += a.shrink * shrink_unit;
-                }
-                ms = clamp_size(ms, a.main_min, a.main_max);
-                if (ms < 0.0f) {
-                    ms = 0.0f;
-                }
-
-                /* Cross size — start from preferred. If align=stretch and the
-                 * preferred is 0 (auto), use content_cross. Then clamp. */
-                float cs = a.cross_pref;
-                if (cs == 0.0f && pl->align == YETTY_YGUI_ALIGN_STRETCH) {
-                    cs = content_cross;
-                }
-                cs = clamp_size(cs, a.cross_min, a.cross_max);
-
-                main_sizes[idx] = ms;
-                cross_sizes[idx] = cs;
-                total_main += ms;
-                idx++;
+                child_total++;
             }
             struct yetty_yclass_object_ptr_result next_res = yetty_ygui_widget_next_sibling(c);
-            if (YETTY_IS_ERR(next_res)) {
-                loop_r = YETTY_ERR(yetty_ycore_void, "layout_node: next_sibling", next_res);
-                goto cleanup;
-            }
+            YETTY_RETURN_IF_ERR(yetty_ycore_void, next_res, "layout_node: count next_sibling");
             c = next_res.value;
         }
     }
-
-    int placed_count = idx;
-    float total_with_gaps = total_main + total_gap;
-
-    /* Justify on the main axis. */
-    float main_offset = 0.0f;
-    float gap_between = pl->gap;
-    if (free_space > 0.0f && grow_unit == 0.0f) {
-        /* No grow children consumed the free space — distribute via
-         * justify-content. */
-        switch (pl->justify) {
-        case YETTY_YGUI_JUSTIFY_CENTER:
-            main_offset = (content_main - total_with_gaps) * 0.5f;
-            break;
-        case YETTY_YGUI_JUSTIFY_END:
-            main_offset = content_main - total_with_gaps;
-            break;
-        case YETTY_YGUI_JUSTIFY_SPACE_BETWEEN:
-            if (placed_count > 1) {
-                gap_between += (content_main - total_with_gaps) / (float)(placed_count - 1);
-            }
-            break;
-        case YETTY_YGUI_JUSTIFY_START:
-        default:
-            break;
-        }
+    if (child_total == 0) {
+        return YETTY_OK_VOID();
     }
 
-    /* Place children. A scrolling container carries a main-axis scroll
-     * offset; subtract it so its in-flow children slide toward the
-     * content-box origin. 0 for non-scrolling nodes. */
-    idx = 0;
-    struct yetty_ycore_float_result scroll_res = yetty_ygui_widget_scroll_main_get(node);
-    if (YETTY_IS_ERR(scroll_res)) {
-        loop_r = YETTY_ERR(yetty_ycore_void, "layout_node: scroll_main_get", scroll_res);
-        goto cleanup;
+    struct flex_item *items = calloc((size_t)child_total, sizeof(*items));
+    if (!items) {
+        return YETTY_ERR(yetty_ycore_void, "layout_node: alloc items");
     }
-    float cursor_main = main_offset - scroll_res.value;
+
+    int item_count = 0;
     {
         struct yetty_yclass_object_ptr_result iter_res = yetty_ygui_widget_first_child(node);
         if (YETTY_IS_ERR(iter_res)) {
-            loop_r = YETTY_ERR(yetty_ycore_void, "layout_node: place first_child", iter_res);
+            loop_r = YETTY_ERR(yetty_ycore_void, "layout_node: resolve first_child", iter_res);
             goto cleanup;
         }
-        for (struct yetty_yclass_object *c = iter_res.value; c && idx < placed_count;) {
+        for (struct yetty_yclass_object *c = iter_res.value; c && item_count < child_total;) {
             struct yetty_ygui_layout_const_ptr_result child_layout_res =
                 yetty_ygui_widget_layout_get(c);
             if (YETTY_IS_ERR(child_layout_res)) {
-                loop_r = YETTY_ERR(yetty_ycore_void, "layout_node: place child layout_get",
+                loop_r = YETTY_ERR(yetty_ycore_void, "layout_node: resolve layout_get",
                                    child_layout_res);
                 goto cleanup;
             }
             const struct yetty_ygui_layout *cl = child_layout_res.value;
-            /* Hidden children were skipped in the sizing pass (no idx
-             * consumed); absolute children were already placed above. */
             if (!cl->hidden && !cl->absolute) {
-                float ms = main_sizes[idx];
-                float cs = cross_sizes[idx];
-
-                /* Cross-axis offset depending on parent align. */
-                float cross_offset = 0.0f;
-                switch (pl->align) {
-                case YETTY_YGUI_ALIGN_CENTER:
-                    cross_offset = (content_cross - cs) * 0.5f;
-                    break;
-                case YETTY_YGUI_ALIGN_END:
-                    cross_offset = content_cross - cs;
-                    break;
-                case YETTY_YGUI_ALIGN_STRETCH:
-                    /* cs already = content_cross (computed above). */
-                    cross_offset = 0.0f;
-                    break;
-                case YETTY_YGUI_ALIGN_START:
-                default:
-                    cross_offset = 0.0f;
-                    break;
-                }
-
-                struct yetty_ycore_rectangle crect;
-                if (direction_is_row(pl)) {
-                    crect.min.x = content_min_x + cursor_main;
-                    crect.min.y = content_min_y + cross_offset;
-                    crect.max.x = crect.min.x + ms;
-                    crect.max.y = crect.min.y + cs;
-                } else {
-                    crect.min.x = content_min_x + cross_offset;
-                    crect.min.y = content_min_y + cursor_main;
-                    crect.max.x = crect.min.x + cs;
-                    crect.max.y = crect.min.y + ms;
-                }
-
-                loop_r = layout_node(c, crect);
-                if (YETTY_IS_ERR(loop_r)) {
+                struct flex_item_result item_res = resolve_flex_item(pl, c);
+                if (YETTY_IS_ERR(item_res)) {
+                    loop_r =
+                        YETTY_ERR(yetty_ycore_void, "layout_node: resolve_flex_item", item_res);
                     goto cleanup;
                 }
-
-                cursor_main += ms + gap_between;
-                idx++;
+                items[item_count++] = item_res.value;
             }
             struct yetty_yclass_object_ptr_result next_res = yetty_ygui_widget_next_sibling(c);
             if (YETTY_IS_ERR(next_res)) {
-                loop_r = YETTY_ERR(yetty_ycore_void, "layout_node: place next_sibling", next_res);
+                loop_r = YETTY_ERR(yetty_ycore_void, "layout_node: resolve next_sibling", next_res);
                 goto cleanup;
             }
             c = next_res.value;
         }
     }
 
+    /* Break into lines. NOWRAP is a single line of all items. WRAP starts a new
+     * line whenever the next item's base + its margins (+ a gap) would overflow
+     * the main axis; a single over-large item still occupies its own line. */
+    float cross_cursor = 0.0f;
+    if (pl->wrap == YETTY_YGUI_WRAP_NOWRAP) {
+        resolve_line_main(items, 0, item_count, content_main, pl->gap);
+        loop_r = place_line(items, 0, item_count, pl, content_min_x, content_min_y, content_main,
+                            pl->gap, scroll, 0.0f, content_cross);
+        if (YETTY_IS_ERR(loop_r)) {
+            goto cleanup;
+        }
+    } else {
+        int line_start = 0;
+        float line_main = 0.0f;
+        int on_line = 0;
+        for (int i = 0; i < item_count; ++i) {
+            float need =
+                items[i].base_main + items[i].margin_main_lead + items[i].margin_main_trail;
+            float with_gap = need + (on_line > 0 ? pl->gap : 0.0f);
+            /* A child that would overflow the current line (and isn't the only
+             * one on it) flushes the line first, then starts the next one. */
+            if (on_line > 0 && line_main + with_gap > content_main) {
+                float line_cross = 0.0f;
+                loop_r =
+                    flush_wrap_line(items, line_start, i - line_start, pl, content_min_x,
+                                    content_min_y, content_main, scroll, cross_cursor, &line_cross);
+                if (YETTY_IS_ERR(loop_r)) {
+                    goto cleanup;
+                }
+                cross_cursor += line_cross + pl->gap;
+                line_start = i;
+                line_main = 0.0f;
+                on_line = 0;
+            }
+            line_main += need + (on_line > 0 ? pl->gap : 0.0f);
+            on_line++;
+        }
+        if (on_line > 0) {
+            float line_cross = 0.0f;
+            loop_r =
+                flush_wrap_line(items, line_start, item_count - line_start, pl, content_min_x,
+                                content_min_y, content_main, scroll, cross_cursor, &line_cross);
+            if (YETTY_IS_ERR(loop_r)) {
+                goto cleanup;
+            }
+        }
+    }
+
 cleanup:
-    free(main_sizes);
-    free(cross_sizes);
+    free(items);
     if (YETTY_IS_ERR(loop_r)) {
         return YETTY_ERR(yetty_ycore_void, "layout_node: child", loop_r);
     }

--- a/src/yetty/ygui/model.yaml
+++ b/src/yetty/ygui/model.yaml
@@ -2983,7 +2983,41 @@ exposed:
         type: "const struct yetty_yclass *"
       - name: method_id
         type: yetty_yclass_method_id_t
-    doc: null
+    doc: "/*
+ * Generic \"call the parent's implementation of this slot\" helpers.
+ *
+ * ABI CONTRACT: read before adding a new caller. These two generic helpers
+ * cast the resolved parent impl to a function pointer that takes only:
+ *
+ *     (struct yetty_yclass_object *)
+ *
+ * They are therefore valid only for slots whose implementation signature is
+ * exactly that. In the current ygui widget slot set, that means constructor
+ * and destructor for super_void.
+ *
+ * They must not be used for slots that carry extra parameters. In particular,
+ * these widget slots have wider signatures:
+ *
+ *     widget_on_press(obj, float x, float y, int button)
+ *     widget_on_release(obj, float x, float y, int button)
+ *     widget_on_motion(obj, float x, float y)
+ *     widget_on_scroll(obj, float x, float y, float dx, float dy)
+ *     widget_paint(obj, struct yetty_ygui_emit_ctx *)
+ *     widget_emit_container(obj, struct yetty_ygui_emit_ctx *)
+ *     widget_emit_body(obj, struct yetty_ygui_emit_ctx *)
+ *
+ * Routing one of those through super_void/super_int casts away the extra
+ * arguments and calls with the wrong ABI (undefined behavior). If a subclass
+ * needs to chain to a parent implementation for a wider slot, add a typed
+ * per-slot super helper with the matching signature rather than widening
+ * these generic helpers.
+ *
+ * This contract is ENFORCED at runtime, not merely documented: super_void
+ * rejects any method_id other than constructor/destructor, and super_int —
+ * for which no valid (obj)-only int virtual exists and which has no callers —
+ * rejects unconditionally. Both return a Result error rather than performing
+ * the unsafe cast, so misuse fails loudly at the call site.
+ */"
   - source_file: src/yetty/ygui/widget.c
     name: yetty_ygui_super_int
     return_type: struct yetty_ycore_int_result
@@ -2994,6 +3028,126 @@ exposed:
         type: "const struct yetty_yclass *"
       - name: method_id
         type: yetty_yclass_method_id_t
+    doc: null
+  - source_file: src/yetty/ygui/widget.c
+    name: yetty_ygui_super_on_press
+    return_type: struct yetty_ycore_int_result
+    args:
+      - name: obj
+        type: "struct yetty_yclass_object *"
+      - name: self_class
+        type: "const struct yetty_yclass *"
+      - name: x
+        type: float
+      - name: y
+        type: float
+      - name: button
+        type: int
+    doc: null
+  - source_file: src/yetty/ygui/widget.c
+    name: yetty_ygui_super_on_release
+    return_type: struct yetty_ycore_int_result
+    args:
+      - name: obj
+        type: "struct yetty_yclass_object *"
+      - name: self_class
+        type: "const struct yetty_yclass *"
+      - name: x
+        type: float
+      - name: y
+        type: float
+      - name: button
+        type: int
+    doc: null
+  - source_file: src/yetty/ygui/widget.c
+    name: yetty_ygui_super_on_motion
+    return_type: struct yetty_ycore_int_result
+    args:
+      - name: obj
+        type: "struct yetty_yclass_object *"
+      - name: self_class
+        type: "const struct yetty_yclass *"
+      - name: x
+        type: float
+      - name: y
+        type: float
+    doc: null
+  - source_file: src/yetty/ygui/widget.c
+    name: yetty_ygui_super_on_scroll
+    return_type: struct yetty_ycore_int_result
+    args:
+      - name: obj
+        type: "struct yetty_yclass_object *"
+      - name: self_class
+        type: "const struct yetty_yclass *"
+      - name: x
+        type: float
+      - name: y
+        type: float
+      - name: dx
+        type: float
+      - name: dy
+        type: float
+    doc: null
+  - source_file: src/yetty/ygui/widget.c
+    name: yetty_ygui_mixin_on_press
+    return_type: struct yetty_ycore_int_result
+    args:
+      - name: obj
+        type: "struct yetty_yclass_object *"
+      - name: mixin_class
+        type: "const struct yetty_yclass *"
+      - name: x
+        type: float
+      - name: y
+        type: float
+      - name: button
+        type: int
+    doc: null
+  - source_file: src/yetty/ygui/widget.c
+    name: yetty_ygui_mixin_on_release
+    return_type: struct yetty_ycore_int_result
+    args:
+      - name: obj
+        type: "struct yetty_yclass_object *"
+      - name: mixin_class
+        type: "const struct yetty_yclass *"
+      - name: x
+        type: float
+      - name: y
+        type: float
+      - name: button
+        type: int
+    doc: null
+  - source_file: src/yetty/ygui/widget.c
+    name: yetty_ygui_mixin_on_motion
+    return_type: struct yetty_ycore_int_result
+    args:
+      - name: obj
+        type: "struct yetty_yclass_object *"
+      - name: mixin_class
+        type: "const struct yetty_yclass *"
+      - name: x
+        type: float
+      - name: y
+        type: float
+    doc: null
+  - source_file: src/yetty/ygui/widget.c
+    name: yetty_ygui_mixin_on_scroll
+    return_type: struct yetty_ycore_int_result
+    args:
+      - name: obj
+        type: "struct yetty_yclass_object *"
+      - name: mixin_class
+        type: "const struct yetty_yclass *"
+      - name: x
+        type: float
+      - name: y
+        type: float
+      - name: dx
+        type: float
+      - name: dy
+        type: float
     doc: null
   - source_file: src/yetty/ygui/widget.c
     name: yetty_ygui_class_expect
@@ -4865,6 +5019,19 @@ types:
         value: 2
       - name: YETTY_YGUI_ALIGN_STRETCH
         value: 3
+  - name: yetty_ygui_flex_align_self
+    kind: enum
+    values:
+      - name: YETTY_YGUI_ALIGN_SELF_AUTO
+        value: 0
+      - name: YETTY_YGUI_ALIGN_SELF_START
+        value: 1
+      - name: YETTY_YGUI_ALIGN_SELF_CENTER
+        value: 2
+      - name: YETTY_YGUI_ALIGN_SELF_END
+        value: 3
+      - name: YETTY_YGUI_ALIGN_SELF_STRETCH
+        value: 4
   - name: yetty_ygui_flex_direction
     kind: enum
     values:
@@ -4883,6 +5050,13 @@ types:
         value: 2
       - name: YETTY_YGUI_JUSTIFY_SPACE_BETWEEN
         value: 3
+  - name: yetty_ygui_flex_wrap
+    kind: enum
+    values:
+      - name: YETTY_YGUI_WRAP_NOWRAP
+        value: 0
+      - name: YETTY_YGUI_WRAP_WRAP
+        value: 1
   - name: yetty_ygui_input_state
     kind: struct
     fields:
@@ -4901,6 +5075,10 @@ types:
         type: enum yetty_ygui_flex_justify
       - name: align
         type: enum yetty_ygui_flex_align
+      - name: align_self
+        type: enum yetty_ygui_flex_align_self
+      - name: wrap
+        type: enum yetty_ygui_flex_wrap
       - name: gap
         type: float
       - name: padding_top
@@ -4910,6 +5088,14 @@ types:
       - name: padding_bottom
         type: float
       - name: padding_left
+        type: float
+      - name: margin_top
+        type: float
+      - name: margin_right
+        type: float
+      - name: margin_bottom
+        type: float
+      - name: margin_left
         type: float
       - name: width
         type: float
@@ -4982,6 +5168,8 @@ local_types:
   yetty_ygui_flex_direction: src/yetty/ygui/widget.c
   yetty_ygui_flex_justify: src/yetty/ygui/widget.c
   yetty_ygui_flex_align: src/yetty/ygui/widget.c
+  yetty_ygui_flex_align_self: src/yetty/ygui/widget.c
+  yetty_ygui_flex_wrap: src/yetty/ygui/widget.c
   yetty_ygui_layout: src/yetty/ygui/widget.c
   yetty_ygui_widget: src/yetty/ygui/widget.c
   yetty_ygui_widget_ptr_result: src/yetty/ygui/widget.c

--- a/src/yetty/ygui/widget.c
+++ b/src/yetty/ygui/widget.c
@@ -49,15 +49,40 @@ enum yetty_ygui_flex_align {
     YETTY_YGUI_ALIGN_STRETCH,
 };
 
+/* Per-child cross-axis alignment override. AUTO (the zero default, so a
+ * zero-initialized or defaulted layout inherits) means "use the parent's
+ * align"; the rest mirror yetty_ygui_flex_align. */
+enum yetty_ygui_flex_align_self {
+    YETTY_YGUI_ALIGN_SELF_AUTO = 0,
+    YETTY_YGUI_ALIGN_SELF_START,
+    YETTY_YGUI_ALIGN_SELF_CENTER,
+    YETTY_YGUI_ALIGN_SELF_END,
+    YETTY_YGUI_ALIGN_SELF_STRETCH,
+};
+
+/* Single-line vs multi-line flow. NOWRAP (the zero default) keeps the
+ * original single-line algorithm; WRAP breaks children onto new lines when
+ * they overflow the container's main axis. */
+enum yetty_ygui_flex_wrap {
+    YETTY_YGUI_WRAP_NOWRAP = 0,
+    YETTY_YGUI_WRAP_WRAP,
+};
+
 struct yetty_ygui_layout {
     enum yetty_ygui_flex_direction direction;
     enum yetty_ygui_flex_justify justify;
     enum yetty_ygui_flex_align align;
+    enum yetty_ygui_flex_align_self align_self;
+    enum yetty_ygui_flex_wrap wrap;
     float gap;
     float padding_top;
     float padding_right;
     float padding_bottom;
     float padding_left;
+    float margin_top;
+    float margin_right;
+    float margin_bottom;
+    float margin_left;
     float width;
     float height;
     float flex_grow;
@@ -155,6 +180,20 @@ YETTY_YRESULT_DECLARE(yetty_ygui_layout_const_ptr, const struct yetty_ygui_layou
  * them here. */
 struct yetty_ycore_void_result yetty_ygui_constructor(struct yetty_yclass_object *obj);
 struct yetty_ycore_void_result yetty_ygui_destructor(struct yetty_yclass_object *obj);
+
+/* The pointer-event slot stubs (generated in the appended widget.gen.c). The
+ * typed super/mixin helpers below need their addresses as the slot method ids
+ * and their exact signatures for the dispatch cast; widget.c can't include its
+ * own widget.h, so forward-declare them here (identical to the generated
+ * declarations). */
+struct yetty_ycore_int_result yetty_ygui_widget_on_press(struct yetty_yclass_object *obj, float x,
+                                                         float y, int button);
+struct yetty_ycore_int_result yetty_ygui_widget_on_release(struct yetty_yclass_object *obj, float x,
+                                                           float y, int button);
+struct yetty_ycore_int_result yetty_ygui_widget_on_motion(struct yetty_yclass_object *obj, float x,
+                                                          float y);
+struct yetty_ycore_int_result yetty_ygui_widget_on_scroll(struct yetty_yclass_object *obj, float x,
+                                                          float y, float dx, float dy);
 
 /* Defined lower in this file (the widget tree/lifecycle block), but the
  * geometry setters above it mark the widget dirty — forward-declare. */
@@ -310,7 +349,13 @@ struct yetty_ygui_layout yetty_ygui_layout_default(void)
     l.direction = YETTY_YGUI_FLEX_ROW;
     l.justify = YETTY_YGUI_JUSTIFY_START;
     l.align = YETTY_YGUI_ALIGN_START;
+    l.align_self = YETTY_YGUI_ALIGN_SELF_AUTO;
+    l.wrap = YETTY_YGUI_WRAP_NOWRAP;
     l.gap = 0;
+    l.margin_top = 0;
+    l.margin_right = 0;
+    l.margin_bottom = 0;
+    l.margin_left = 0;
     l.width = -1.0f;
     l.height = -1.0f;
     l.flex_grow = 0;
@@ -400,9 +445,31 @@ struct yetty_ycore_void_result yetty_ygui_widget_layout_set(struct yetty_yclass_
     struct yetty_ygui_widget_ptr_result wd_dr = yetty_ygui_widget_from(obj);
     YETTY_RETURN_IF_ERR(yetty_ycore_void, wd_dr, "yetty_ygui_widget_layout_set: data_get");
     struct yetty_ygui_widget *wd = wd_dr.value;
+    /* No-op when the layout is byte-identical, so a caller re-pushing an
+     * unchanged layout in a hot path does not force an avoidable emit. The
+     * byte compare is a valid equality test only while the struct stays
+     * padding-free; the assert enforces that (every field is a 4-byte
+     * enum/float/int, so the member sizes sum to sizeof the struct). A future
+     * field reorder or a smaller field that introduces padding — which would
+     * make byte equality diverge from value equality — breaks the build here
+     * instead of silently weakening the guard, prompting a switch to a
+     * field-by-field compare. */
+    _Static_assert(
+        sizeof *layout ==
+            sizeof(enum yetty_ygui_flex_direction) + sizeof(enum yetty_ygui_flex_justify) +
+                sizeof(enum yetty_ygui_flex_align) + sizeof(enum yetty_ygui_flex_align_self) +
+                sizeof(enum yetty_ygui_flex_wrap) + 19 * sizeof(float) + 2 * sizeof(int),
+        "struct yetty_ygui_layout must stay padding-free for the layout_set() "
+        "memcmp no-op guard; add the new field here or compare fields semantically");
+    if (memcmp(&wd->layout, layout, sizeof *layout) == 0) {
+        return YETTY_OK_VOID();
+    }
     wd->layout = *layout;
-    wd->dirty = 1;
-    return YETTY_OK_VOID();
+    /* Route through set_dirty (not a bare wd->dirty = 1) so the owning
+     * framework is also marked dirty and the next frame re-emits. Mirrors
+     * set_visible above — a public setter that mutates layout must trigger
+     * a repaint on its own; callers should not have to mark dirty by hand. */
+    return yetty_ygui_widget_set_dirty(obj);
 }
 
 YETTY_ANNOTATE("expose")
@@ -732,6 +799,41 @@ struct yetty_ycore_void_result yetty_ygui_widget_apply_css(struct yetty_yclass_o
  * reached through the checked yetty_ygui_widget_from downcast).
  *=========================================================================*/
 
+/*
+ * Generic "call the parent's implementation of this slot" helpers.
+ *
+ * ABI CONTRACT: read before adding a new caller. These two generic helpers
+ * cast the resolved parent impl to a function pointer that takes only:
+ *
+ *     (struct yetty_yclass_object *)
+ *
+ * They are therefore valid only for slots whose implementation signature is
+ * exactly that. In the current ygui widget slot set, that means constructor
+ * and destructor for super_void.
+ *
+ * They must not be used for slots that carry extra parameters. In particular,
+ * these widget slots have wider signatures:
+ *
+ *     widget_on_press(obj, float x, float y, int button)
+ *     widget_on_release(obj, float x, float y, int button)
+ *     widget_on_motion(obj, float x, float y)
+ *     widget_on_scroll(obj, float x, float y, float dx, float dy)
+ *     widget_paint(obj, struct yetty_ygui_emit_ctx *)
+ *     widget_emit_container(obj, struct yetty_ygui_emit_ctx *)
+ *     widget_emit_body(obj, struct yetty_ygui_emit_ctx *)
+ *
+ * Routing one of those through super_void/super_int casts away the extra
+ * arguments and calls with the wrong ABI (undefined behavior). If a subclass
+ * needs to chain to a parent implementation for a wider slot, add a typed
+ * per-slot super helper with the matching signature rather than widening
+ * these generic helpers.
+ *
+ * This contract is ENFORCED at runtime, not merely documented: super_void
+ * rejects any method_id other than constructor/destructor, and super_int —
+ * for which no valid (obj)-only int virtual exists and which has no callers —
+ * rejects unconditionally. Both return a Result error rather than performing
+ * the unsafe cast, so misuse fails loudly at the call site.
+ */
 YETTY_ANNOTATE("expose")
 struct yetty_ycore_void_result yetty_ygui_super_void(struct yetty_yclass_object *obj,
                                                      const struct yetty_yclass *self_class,
@@ -739,6 +841,17 @@ struct yetty_ycore_void_result yetty_ygui_super_void(struct yetty_yclass_object 
 {
     if (!obj || !self_class || !method_id) {
         return YETTY_ERR(yetty_ycore_void, "yetty_ygui_super_void: NULL arg");
+    }
+    /* Enforce, don't just document, the ABI contract above: the (obj)-only
+     * cast is safe only for the parameterless void virtuals — constructor and
+     * destructor. Reject any other slot loudly instead of calling a wider one
+     * (on_press / paint / emit_container / …) with the wrong ABI. A wider slot
+     * must get a typed per-slot super helper. */
+    if (method_id != (yetty_yclass_method_id_t)yetty_ygui_constructor &&
+        method_id != (yetty_yclass_method_id_t)yetty_ygui_destructor) {
+        return YETTY_ERR(yetty_ycore_void,
+                         "yetty_ygui_super_void: generic super is only valid for "
+                         "constructor/destructor; a parameter-carrying slot needs a typed helper");
     }
     struct yetty_yclass_method_slot_result slot_result = yetty_ygui_method_slot_get(method_id);
     YETTY_RETURN_IF_ERR(yetty_ycore_void, slot_result, "yetty_ygui_super_void: slot lookup");
@@ -762,24 +875,211 @@ struct yetty_ycore_int_result yetty_ygui_super_int(struct yetty_yclass_object *o
                                                    const struct yetty_yclass *self_class,
                                                    yetty_yclass_method_id_t method_id)
 {
-    if (!obj || !self_class || !method_id) {
-        return YETTY_ERR(yetty_ycore_int, "yetty_ygui_super_int: NULL arg");
-    }
+    (void)obj;
+    (void)self_class;
+    (void)method_id;
+    /* Every int widget virtual is a pointer-event handler (on_press /
+     * on_release / on_motion / on_scroll) that carries x/y/button/… args, so
+     * the (obj)-only cast this helper would use is ABI-unsafe for all of them,
+     * and there is no (obj)-only int virtual it could serve. It has no callers.
+     * Reject unconditionally rather than expose an unsafe dispatch path; add a
+     * typed per-slot super if a genuine (obj)-only int virtual ever appears. */
+    return YETTY_ERR(yetty_ycore_int,
+                     "yetty_ygui_super_int: no (obj)-only int virtual exists; a pointer-event "
+                     "slot needs a typed per-slot super helper");
+}
+
+/*===========================================================================
+ * Typed per-slot chaining for the pointer-event virtuals (on_press /
+ * on_release / on_motion / on_scroll). Unlike the generic super_void/super_int
+ * these carry the slot's real signature, so a leaf override can safely call:
+ *
+ *   - the PARENT's implementation via yetty_ygui_super_on_<slot>() — walks the
+ *     parent chain (yetty_yclass_parent), exactly like super_void but ABI-safe
+ *     for the extra x/y/button/… arguments; and
+ *   - a specific MIXIN's implementation via yetty_ygui_mixin_on_<slot>() —
+ *     looks the slot up directly on the named mixin class. Because dispatch is
+ *     a flat overwrite (a leaf override replaces a mixin's slot; see the yclass
+ *     README), this is how a widget that both `uses@` a behavior mixin AND
+ *     overrides the slot itself runs the mixin's part explicitly — the missing
+ *     composition path that a flat vtable cannot provide automatically.
+ *
+ * A slot the target class doesn't implement resolves to NULL and no-ops
+ * (returns 0 = not-consumed), matching the historic "un-overridden slot
+ * silently does nothing" contract.
+ *
+ * yetty_ygui_mixin_on_* is a DIRECT slot lookup on the class you pass — it does
+ * not verify that class is actually a mixin the object `uses@`. Passing an
+ * unrelated class simply dispatches that class's slot impl (or no-ops if it has
+ * none); the intent is that callers pass a mixin their own class composes.
+ *=========================================================================*/
+
+static struct yetty_yclass_impl_t_result ygui_super_impl(const struct yetty_yclass *self_class,
+                                                         yetty_yclass_method_id_t method_id)
+{
     struct yetty_yclass_method_slot_result slot_result = yetty_ygui_method_slot_get(method_id);
-    YETTY_RETURN_IF_ERR(yetty_ycore_int, slot_result, "yetty_ygui_super_int: slot lookup");
-    yetty_yclass_method_slot slot = slot_result.value;
-    if (slot == YETTY_YCLASS_METHOD_SLOT_UNDEFINED) {
-        return YETTY_ERR(yetty_ycore_int, "yetty_ygui_super_int: slot lookup failed");
+    YETTY_RETURN_IF_ERR(yetty_yclass_impl_t, slot_result, "ygui_super_impl: slot lookup");
+    if (slot_result.value == YETTY_YCLASS_METHOD_SLOT_UNDEFINED) {
+        return YETTY_OK(yetty_yclass_impl_t, NULL);
+    }
+    return yetty_ygui_dispatch_lookup_super(self_class, slot_result.value);
+}
+
+static struct yetty_yclass_impl_t_result ygui_mixin_impl(const struct yetty_yclass *mixin_class,
+                                                         yetty_yclass_method_id_t method_id)
+{
+    struct yetty_yclass_method_slot_result slot_result = yetty_ygui_method_slot_get(method_id);
+    YETTY_RETURN_IF_ERR(yetty_yclass_impl_t, slot_result, "ygui_mixin_impl: slot lookup");
+    if (slot_result.value == YETTY_YCLASS_METHOD_SLOT_UNDEFINED) {
+        return YETTY_OK(yetty_yclass_impl_t, NULL);
+    }
+    return yetty_ygui_dispatch_lookup(mixin_class, slot_result.value);
+}
+
+YETTY_ANNOTATE("expose")
+struct yetty_ycore_int_result yetty_ygui_super_on_press(struct yetty_yclass_object *obj,
+                                                        const struct yetty_yclass *self_class,
+                                                        float x, float y, int button)
+{
+    if (!obj || !self_class) {
+        return YETTY_ERR(yetty_ycore_int, "yetty_ygui_super_on_press: NULL arg");
     }
     struct yetty_yclass_impl_t_result impl_result =
-        yetty_ygui_dispatch_lookup_super(self_class, slot);
-    YETTY_RETURN_IF_ERR(yetty_ycore_int, impl_result, "yetty_ygui_super_int: dispatch lookup");
-    yetty_yclass_impl_t impl = impl_result.value;
-    if (!impl) {
+        ygui_super_impl(self_class, (yetty_yclass_method_id_t)yetty_ygui_widget_on_press);
+    YETTY_RETURN_IF_ERR(yetty_ycore_int, impl_result, "yetty_ygui_super_on_press: resolve");
+    if (!impl_result.value) {
         return YETTY_OK(yetty_ycore_int, 0);
     }
-    typedef struct yetty_ycore_int_result (*fn_t)(struct yetty_yclass_object *);
-    return ((fn_t)impl)((struct yetty_yclass_object *)obj);
+    typedef struct yetty_ycore_int_result (*fn_t)(struct yetty_yclass_object *, float, float, int);
+    return ((fn_t)impl_result.value)(obj, x, y, button);
+}
+
+YETTY_ANNOTATE("expose")
+struct yetty_ycore_int_result yetty_ygui_super_on_release(struct yetty_yclass_object *obj,
+                                                          const struct yetty_yclass *self_class,
+                                                          float x, float y, int button)
+{
+    if (!obj || !self_class) {
+        return YETTY_ERR(yetty_ycore_int, "yetty_ygui_super_on_release: NULL arg");
+    }
+    struct yetty_yclass_impl_t_result impl_result =
+        ygui_super_impl(self_class, (yetty_yclass_method_id_t)yetty_ygui_widget_on_release);
+    YETTY_RETURN_IF_ERR(yetty_ycore_int, impl_result, "yetty_ygui_super_on_release: resolve");
+    if (!impl_result.value) {
+        return YETTY_OK(yetty_ycore_int, 0);
+    }
+    typedef struct yetty_ycore_int_result (*fn_t)(struct yetty_yclass_object *, float, float, int);
+    return ((fn_t)impl_result.value)(obj, x, y, button);
+}
+
+YETTY_ANNOTATE("expose")
+struct yetty_ycore_int_result yetty_ygui_super_on_motion(struct yetty_yclass_object *obj,
+                                                         const struct yetty_yclass *self_class,
+                                                         float x, float y)
+{
+    if (!obj || !self_class) {
+        return YETTY_ERR(yetty_ycore_int, "yetty_ygui_super_on_motion: NULL arg");
+    }
+    struct yetty_yclass_impl_t_result impl_result =
+        ygui_super_impl(self_class, (yetty_yclass_method_id_t)yetty_ygui_widget_on_motion);
+    YETTY_RETURN_IF_ERR(yetty_ycore_int, impl_result, "yetty_ygui_super_on_motion: resolve");
+    if (!impl_result.value) {
+        return YETTY_OK(yetty_ycore_int, 0);
+    }
+    typedef struct yetty_ycore_int_result (*fn_t)(struct yetty_yclass_object *, float, float);
+    return ((fn_t)impl_result.value)(obj, x, y);
+}
+
+YETTY_ANNOTATE("expose")
+struct yetty_ycore_int_result yetty_ygui_super_on_scroll(struct yetty_yclass_object *obj,
+                                                         const struct yetty_yclass *self_class,
+                                                         float x, float y, float dx, float dy)
+{
+    if (!obj || !self_class) {
+        return YETTY_ERR(yetty_ycore_int, "yetty_ygui_super_on_scroll: NULL arg");
+    }
+    struct yetty_yclass_impl_t_result impl_result =
+        ygui_super_impl(self_class, (yetty_yclass_method_id_t)yetty_ygui_widget_on_scroll);
+    YETTY_RETURN_IF_ERR(yetty_ycore_int, impl_result, "yetty_ygui_super_on_scroll: resolve");
+    if (!impl_result.value) {
+        return YETTY_OK(yetty_ycore_int, 0);
+    }
+    typedef struct yetty_ycore_int_result (*fn_t)(struct yetty_yclass_object *, float, float, float,
+                                                  float);
+    return ((fn_t)impl_result.value)(obj, x, y, dx, dy);
+}
+
+YETTY_ANNOTATE("expose")
+struct yetty_ycore_int_result yetty_ygui_mixin_on_press(struct yetty_yclass_object *obj,
+                                                        const struct yetty_yclass *mixin_class,
+                                                        float x, float y, int button)
+{
+    if (!obj || !mixin_class) {
+        return YETTY_ERR(yetty_ycore_int, "yetty_ygui_mixin_on_press: NULL arg");
+    }
+    struct yetty_yclass_impl_t_result impl_result =
+        ygui_mixin_impl(mixin_class, (yetty_yclass_method_id_t)yetty_ygui_widget_on_press);
+    YETTY_RETURN_IF_ERR(yetty_ycore_int, impl_result, "yetty_ygui_mixin_on_press: resolve");
+    if (!impl_result.value) {
+        return YETTY_OK(yetty_ycore_int, 0);
+    }
+    typedef struct yetty_ycore_int_result (*fn_t)(struct yetty_yclass_object *, float, float, int);
+    return ((fn_t)impl_result.value)(obj, x, y, button);
+}
+
+YETTY_ANNOTATE("expose")
+struct yetty_ycore_int_result yetty_ygui_mixin_on_release(struct yetty_yclass_object *obj,
+                                                          const struct yetty_yclass *mixin_class,
+                                                          float x, float y, int button)
+{
+    if (!obj || !mixin_class) {
+        return YETTY_ERR(yetty_ycore_int, "yetty_ygui_mixin_on_release: NULL arg");
+    }
+    struct yetty_yclass_impl_t_result impl_result =
+        ygui_mixin_impl(mixin_class, (yetty_yclass_method_id_t)yetty_ygui_widget_on_release);
+    YETTY_RETURN_IF_ERR(yetty_ycore_int, impl_result, "yetty_ygui_mixin_on_release: resolve");
+    if (!impl_result.value) {
+        return YETTY_OK(yetty_ycore_int, 0);
+    }
+    typedef struct yetty_ycore_int_result (*fn_t)(struct yetty_yclass_object *, float, float, int);
+    return ((fn_t)impl_result.value)(obj, x, y, button);
+}
+
+YETTY_ANNOTATE("expose")
+struct yetty_ycore_int_result yetty_ygui_mixin_on_motion(struct yetty_yclass_object *obj,
+                                                         const struct yetty_yclass *mixin_class,
+                                                         float x, float y)
+{
+    if (!obj || !mixin_class) {
+        return YETTY_ERR(yetty_ycore_int, "yetty_ygui_mixin_on_motion: NULL arg");
+    }
+    struct yetty_yclass_impl_t_result impl_result =
+        ygui_mixin_impl(mixin_class, (yetty_yclass_method_id_t)yetty_ygui_widget_on_motion);
+    YETTY_RETURN_IF_ERR(yetty_ycore_int, impl_result, "yetty_ygui_mixin_on_motion: resolve");
+    if (!impl_result.value) {
+        return YETTY_OK(yetty_ycore_int, 0);
+    }
+    typedef struct yetty_ycore_int_result (*fn_t)(struct yetty_yclass_object *, float, float);
+    return ((fn_t)impl_result.value)(obj, x, y);
+}
+
+YETTY_ANNOTATE("expose")
+struct yetty_ycore_int_result yetty_ygui_mixin_on_scroll(struct yetty_yclass_object *obj,
+                                                         const struct yetty_yclass *mixin_class,
+                                                         float x, float y, float dx, float dy)
+{
+    if (!obj || !mixin_class) {
+        return YETTY_ERR(yetty_ycore_int, "yetty_ygui_mixin_on_scroll: NULL arg");
+    }
+    struct yetty_yclass_impl_t_result impl_result =
+        ygui_mixin_impl(mixin_class, (yetty_yclass_method_id_t)yetty_ygui_widget_on_scroll);
+    YETTY_RETURN_IF_ERR(yetty_ycore_int, impl_result, "yetty_ygui_mixin_on_scroll: resolve");
+    if (!impl_result.value) {
+        return YETTY_OK(yetty_ycore_int, 0);
+    }
+    typedef struct yetty_ycore_int_result (*fn_t)(struct yetty_yclass_object *, float, float, float,
+                                                  float);
+    return ((fn_t)impl_result.value)(obj, x, y, dx, dy);
 }
 
 YETTY_ANNOTATE("expose")

--- a/test/ut/ygui/behavior-test.c
+++ b/test/ut/ygui/behavior-test.c
@@ -14,7 +14,9 @@
  * Pure event/state logic — no GPU/display/network.
  */
 
+#include <yetty/ygui/mixins/clickable.h>
 #include <yetty/ygui/mixins/draggable.h>
+#include <yetty/ygui/widgets/panel.h>
 #include <yetty/ygui/widgets/radio.h>
 #include <yetty/ygui/widgets/scrollarea.h>
 #include <yetty/ygui/widgets/selectable.h>
@@ -214,6 +216,86 @@ static void test_tabbar_model(struct ytest *test)
     yetty_ygui_widget_destroy(tb);
 }
 
+/*---------------------------------------------------------------------------
+ * Mixin/parent/leaf slot-collision order + the typed super/mixin chaining
+ * helpers. selectable `uses@ygui:clickable` and does NOT override on_press, so
+ * dispatch resolves its on_press to the clickable mixin's impl — which overrode
+ * the base widget's no-op default (registration order is parent -> mixins ->
+ * leaf, each overwriting). clickable's on_press sets the observable `pressed`
+ * flag and consumes; its on_release clears pressed and fires the on_click that
+ * toggles selectable's `selected`.
+ *-------------------------------------------------------------------------*/
+static int sel_selected(struct ytest *test, struct yetty_yclass_object *w)
+{
+    struct yetty_ycore_int_result r = yetty_ygui_selectable_is_selected(w);
+    YTEST_REQUIRE_OK(test, r);
+    return r.value;
+}
+static int clickable_pressed(struct ytest *test, struct yetty_yclass_object *w)
+{
+    struct yetty_ycore_int_result r = yetty_ygui_clickable_is_pressed(w);
+    YTEST_REQUIRE_OK(test, r);
+    return r.value;
+}
+
+static void test_slot_precedence(struct ytest *test)
+{
+    struct yetty_yclass_object *sel = make(test, yetty_ygui_selectable_class_get());
+
+    /* PARENT level: super walks selectable's parent chain to the base widget,
+     * whose on_press is the no-op default — returns 0 and never touches the
+     * clickable slice. */
+    struct yetty_ycore_int_result parent_press =
+        yetty_ygui_super_on_press(sel, yetty_ygui_selectable_class_get().value, 1.0f, 1.0f, 0);
+    YTEST_REQUIRE_OK(test, parent_press);
+    YTEST_CHECK_EQ_INT(test, parent_press.value, 0);
+    YTEST_CHECK_EQ_INT(test, clickable_pressed(test, sel), 0);
+
+    /* DISPATCH level: with no leaf override, the on_press selectable actually
+     * runs is the clickable mixin's (mixin beat the parent default). So a normal
+     * press consumes AND sets the clickable pressed flag — proving the mixin
+     * slot, not the parent's 0, is installed. */
+    struct yetty_ycore_int_result disp = yetty_ygui_widget_on_press(sel, 1.0f, 1.0f, 0);
+    YTEST_REQUIRE_OK(test, disp);
+    YTEST_CHECK_EQ_INT(test, disp.value, 1);
+    YTEST_CHECK_EQ_INT(test, clickable_pressed(test, sel), 1);
+
+    yetty_ygui_widget_destroy(sel);
+}
+
+static void test_mixin_dispatch_helper(struct ytest *test)
+{
+    struct yetty_yclass_object *sel = make(test, yetty_ygui_selectable_class_get());
+    YTEST_CHECK_EQ_INT(test, sel_selected(test, sel), 0);
+    YTEST_CHECK_EQ_INT(test, clickable_pressed(test, sel), 0);
+
+    /* Invoke the clickable mixin's press EXPLICITLY via the typed mixin helper —
+     * the "run the mixin's part" path a leaf override would use. It dispatches
+     * to clickable's on_press: consumes and sets pressed. */
+    struct yetty_ycore_int_result mp =
+        yetty_ygui_mixin_on_press(sel, yetty_ygui_clickable_mixin_get().value, 2.0f, 2.0f, 0);
+    YTEST_REQUIRE_OK(test, mp);
+    YTEST_CHECK_EQ_INT(test, mp.value, 1);
+    YTEST_CHECK_EQ_INT(test, clickable_pressed(test, sel), 1);
+
+    /* Release through the mixin helper clears pressed and fires on_click, which
+     * toggles selected. */
+    struct yetty_ycore_int_result mr =
+        yetty_ygui_mixin_on_release(sel, yetty_ygui_clickable_mixin_get().value, 2.0f, 2.0f, 0);
+    YTEST_REQUIRE_OK(test, mr);
+    YTEST_CHECK_EQ_INT(test, clickable_pressed(test, sel), 0);
+    YTEST_CHECK_EQ_INT(test, sel_selected(test, sel), 1);
+
+    /* A class that does not implement the slot resolves to no impl → the helper
+     * no-ops (returns 0) rather than faulting. */
+    struct yetty_ycore_int_result none =
+        yetty_ygui_mixin_on_press(sel, yetty_ygui_panel_class_get().value, 2.0f, 2.0f, 0);
+    YTEST_REQUIRE_OK(test, none);
+    YTEST_CHECK_EQ_INT(test, none.value, 0);
+
+    yetty_ygui_widget_destroy(sel);
+}
+
 int main(void)
 {
     struct ytest test = ytest_begin("ygui_behavior");
@@ -221,6 +303,8 @@ int main(void)
     YTEST_RUN(&test, test_draggable_sequence);
     YTEST_RUN(&test, test_radio_click_selects);
     YTEST_RUN(&test, test_selectable_click_toggles);
+    YTEST_RUN(&test, test_slot_precedence);
+    YTEST_RUN(&test, test_mixin_dispatch_helper);
     YTEST_RUN(&test, test_tabbar_model);
     return ytest_end(&test);
 }

--- a/test/ut/ygui/figure-test.c
+++ b/test/ut/ygui/figure-test.c
@@ -185,6 +185,48 @@ static int child_present(struct ytest *test, struct yetty_yclass_object *contain
     return child_res.value != NULL;
 }
 
+static struct yetty_ycore_void_result count_click(struct yetty_yclass_object *obj, void *userdata)
+{
+    (void)obj;
+    (*(int *)userdata)++;
+    return YETTY_OK_VOID();
+}
+
+static void make_headless_framework(struct ytest *test,
+                                    struct yetty_yfigure_registry **out_registry,
+                                    struct yetty_yclass_object **out_container,
+                                    struct yetty_yclass_object **out_engine,
+                                    struct yetty_yclass_object **out_root)
+{
+    struct yetty_yfigure_registry *registry = make_registry(test);
+    struct yetty_yclass_ctx yclass_ctx = {0};
+    struct yetty_yclass_object_ptr_result cont_res = yetty_yfigure_container_create(&yclass_ctx);
+    YTEST_REQUIRE_OK(test, cont_res);
+    struct yetty_yclass_object *container = cont_res.value;
+    struct yetty_ycore_rectangle container_rect = {{0, 0}, {800, 600}};
+    yetty_yfigure_container_set_registry(container, registry);
+    yetty_yfigure_container_set_rect(container, container_rect);
+
+    struct yetty_yclass_object_ptr_result er = yetty_ygui_framework_create(NULL);
+    YTEST_REQUIRE_OK(test, er);
+    struct yetty_yclass_object *engine = er.value;
+    struct yetty_ycore_void_result set_container_res =
+        yetty_ygui_framework_set_container_obj(engine, container);
+    YTEST_REQUIRE_OK(test, set_container_res);
+
+    struct yetty_yclass_object_ptr_result rr =
+        yetty_ygui_widget_new(yetty_ygui_panel_class_get().value);
+    YTEST_REQUIRE_OK(test, rr);
+    struct yetty_yclass_object *root = rr.value;
+    struct yetty_ycore_void_result set_root_res = yetty_ygui_framework_set_root(engine, root);
+    YTEST_REQUIRE_OK(test, set_root_res);
+
+    *out_registry = registry;
+    *out_container = container;
+    *out_engine = engine;
+    *out_root = root;
+}
+
 /* Minimal valid 2x2 24-bit BMP. stb_image (used by yetty_yimage_render)
  * decodes this into RGBA8, so the emit path produces a real drawable_list —
  * handcrafted inline so the headless test needs no on-disk asset. */
@@ -259,6 +301,117 @@ static struct yetty_yclass_object *make_engine_with_yimage(
     *out_container = container;
     *out_img = img;
     return engine;
+}
+
+static void test_layout_set_marks_framework_dirty(struct ytest *test)
+{
+    struct yetty_yfigure_registry *registry = NULL;
+    struct yetty_yclass_object *container = NULL;
+    struct yetty_yclass_object *engine = NULL;
+    struct yetty_yclass_object *root = NULL;
+    make_headless_framework(test, &registry, &container, &engine, &root);
+
+    struct yetty_ycore_void_result emit_res = yetty_ygui_framework_emit(engine);
+    YTEST_REQUIRE_OK(test, emit_res);
+    YTEST_CHECK_EQ_INT(test, yetty_ygui_framework_is_dirty(engine), 0);
+
+    struct yetty_ygui_layout_const_ptr_result layout_res = yetty_ygui_widget_layout_get(root);
+    YTEST_REQUIRE_OK(test, layout_res);
+    struct yetty_ygui_layout layout = *layout_res.value;
+    layout.gap = 7.0f;
+    struct yetty_ycore_void_result set_res = yetty_ygui_widget_layout_set(root, &layout);
+    YTEST_REQUIRE_OK(test, set_res);
+
+    YTEST_CHECK_EQ_INT(test, yetty_ygui_framework_is_dirty(engine), 1);
+
+    yetty_ygui_framework_destroy(engine);
+    yetty_yfigure_destroy(container);
+    yetty_yfigure_registry_destroy(registry);
+}
+
+/* A scrollarea child positioned outside the scrollarea's viewport rect is not
+ * clickable; the same child moved inside the viewport is. This locks the input
+ * side of scrollarea clipping, which hit_test already enforces structurally:
+ * the recursive rect check prunes the scrollarea subtree whenever the pointer
+ * is outside the scrollarea's own rect, so an off-viewport child is never
+ * reached (see hit_test in framework.c). It is a regression guard for that
+ * containment, not for any separate scissor-propagation code. */
+static void test_scrollarea_children_clipped_by_viewport(struct ytest *test)
+{
+    struct yetty_yfigure_registry *registry = NULL;
+    struct yetty_yclass_object *container = NULL;
+    struct yetty_yclass_object *engine = NULL;
+    struct yetty_yclass_object *root = NULL;
+    make_headless_framework(test, &registry, &container, &engine, &root);
+
+    struct yetty_yclass_object_ptr_result sr =
+        yetty_ygui_widget_add(root, yetty_ygui_scrollarea_class_get().value);
+    YTEST_REQUIRE_OK(test, sr);
+    struct yetty_yclass_object *scroll = sr.value;
+    struct yetty_ygui_layout_const_ptr_result scroll_layout_res =
+        yetty_ygui_widget_layout_get(scroll);
+    YTEST_REQUIRE_OK(test, scroll_layout_res);
+    struct yetty_ygui_layout scroll_layout = *scroll_layout_res.value;
+    scroll_layout.width = 100.0f;
+    scroll_layout.height = 100.0f;
+    struct yetty_ycore_void_result scroll_set_res =
+        yetty_ygui_widget_layout_set(scroll, &scroll_layout);
+    YTEST_REQUIRE_OK(test, scroll_set_res);
+
+    struct yetty_yclass_object_ptr_result br =
+        yetty_ygui_widget_add(scroll, yetty_ygui_button_class_get().value);
+    YTEST_REQUIRE_OK(test, br);
+    struct yetty_yclass_object *button = br.value;
+    int clicks = 0;
+    struct yetty_ycore_void_result cb_res =
+        yetty_ygui_clickable_on_click_set(button, count_click, &clicks);
+    YTEST_REQUIRE_OK(test, cb_res);
+
+    struct yetty_ygui_layout_const_ptr_result button_layout_res =
+        yetty_ygui_widget_layout_get(button);
+    YTEST_REQUIRE_OK(test, button_layout_res);
+    struct yetty_ygui_layout button_layout = *button_layout_res.value;
+    button_layout.absolute = 1;
+    button_layout.pos_x = 0.0f;
+    button_layout.pos_y = 150.0f;
+    button_layout.width = 50.0f;
+    button_layout.height = 20.0f;
+    struct yetty_ycore_void_result button_set_res =
+        yetty_ygui_widget_layout_set(button, &button_layout);
+    YTEST_REQUIRE_OK(test, button_set_res);
+
+    struct yetty_ycore_void_result emit1 = yetty_ygui_framework_emit(engine);
+    YTEST_REQUIRE_OK(test, emit1);
+
+    struct yetty_ycore_int_result press_out =
+        yetty_ygui_framework_feed_mouse_button(engine, 10.0f, 160.0f, 0, 1, 0);
+    YTEST_REQUIRE_OK(test, press_out);
+    YTEST_CHECK_EQ_INT(test, press_out.value, 0);
+    struct yetty_ycore_int_result release_out =
+        yetty_ygui_framework_feed_mouse_button(engine, 10.0f, 160.0f, 0, 0, 0);
+    YTEST_REQUIRE_OK(test, release_out);
+    YTEST_CHECK_EQ_INT(test, release_out.value, 0);
+    YTEST_CHECK_EQ_INT(test, clicks, 0);
+
+    button_layout.pos_y = 10.0f;
+    button_set_res = yetty_ygui_widget_layout_set(button, &button_layout);
+    YTEST_REQUIRE_OK(test, button_set_res);
+    struct yetty_ycore_void_result emit2 = yetty_ygui_framework_emit(engine);
+    YTEST_REQUIRE_OK(test, emit2);
+
+    struct yetty_ycore_int_result press_in =
+        yetty_ygui_framework_feed_mouse_button(engine, 10.0f, 20.0f, 0, 1, 0);
+    YTEST_REQUIRE_OK(test, press_in);
+    YTEST_CHECK_EQ_INT(test, press_in.value, 1);
+    struct yetty_ycore_int_result release_in =
+        yetty_ygui_framework_feed_mouse_button(engine, 10.0f, 20.0f, 0, 0, 0);
+    YTEST_REQUIRE_OK(test, release_in);
+    YTEST_CHECK_EQ_INT(test, release_in.value, 1);
+    YTEST_CHECK_EQ_INT(test, clicks, 1);
+
+    yetty_ygui_framework_destroy(engine);
+    yetty_yfigure_destroy(container);
+    yetty_yfigure_registry_destroy(registry);
 }
 
 static void test_yimage_emit(struct ytest *test)
@@ -438,6 +591,8 @@ static void test_yimage_emit_rejects_malformed(struct ytest *test)
 int main(void)
 {
     struct ytest test = ytest_begin("ygui_figure");
+    YTEST_RUN(&test, test_layout_set_marks_framework_dirty);
+    YTEST_RUN(&test, test_scrollarea_children_clipped_by_viewport);
     YTEST_RUN(&test, test_yimage_emit);
     YTEST_RUN(&test, test_incremental_figure_skip);
     YTEST_RUN(&test, test_yimage_emit_rejects_malformed);

--- a/test/ut/ygui/layout-test.c
+++ b/test/ut/ygui/layout-test.c
@@ -335,12 +335,281 @@ static void test_widget_paint_emits_real_prims(struct ytest *test)
     yetty_ygui_widget_destroy(panel);
 }
 
+/* Shrinking with a min clamp must REDISTRIBUTE the deficit a frozen child can't
+ * absorb to its still-flexible siblings, not strand it (the pre-fix behavior
+ * left independent per-child clamps that overflowed the container). */
+static void test_flex_shrink_min_clamp_redistributes(struct ytest *test)
+{
+    struct yetty_yclass_object_ptr_result r =
+        yetty_ygui_widget_new(yetty_ygui_hbox_class_get().value);
+    YTEST_REQUIRE_OK(test, r);
+    struct yetty_yclass_object *root = r.value;
+
+    struct yetty_yclass_object_ptr_result ra =
+        yetty_ygui_widget_add(root, yetty_ygui_label_class_get().value);
+    YTEST_REQUIRE_OK(test, ra);
+    struct yetty_yclass_object_ptr_result rb =
+        yetty_ygui_widget_add(root, yetty_ygui_label_class_get().value);
+    YTEST_REQUIRE_OK(test, rb);
+
+    struct yetty_ygui_layout_const_ptr_result la_res = yetty_ygui_widget_layout_get(ra.value);
+    YTEST_REQUIRE_OK(test, la_res);
+    struct yetty_ygui_layout la = *la_res.value;
+    la.width = 80.0f;
+    la.height = 20.0f;
+    la.flex_shrink = 1.0f;
+    la.min_width = 60.0f; /* A cannot shrink below 60 */
+    yetty_ygui_widget_layout_set(ra.value, &la);
+
+    struct yetty_ygui_layout_const_ptr_result lb_res = yetty_ygui_widget_layout_get(rb.value);
+    YTEST_REQUIRE_OK(test, lb_res);
+    struct yetty_ygui_layout lb = *lb_res.value;
+    lb.width = 80.0f;
+    lb.height = 20.0f;
+    lb.flex_shrink = 1.0f;
+    yetty_ygui_widget_layout_set(rb.value, &lb);
+
+    struct yetty_ygui_layout_const_ptr_result lp_res = yetty_ygui_widget_layout_get(root);
+    YTEST_REQUIRE_OK(test, lp_res);
+    struct yetty_ygui_layout lp = *lp_res.value;
+    lp.direction = YETTY_YGUI_FLEX_ROW;
+    lp.gap = 0.0f;
+    lp.padding_left = lp.padding_right = lp.padding_top = lp.padding_bottom = 0.0f;
+    yetty_ygui_widget_layout_set(root, &lp);
+
+    /* 100 wide, total base 160 → 60 overflow. A floors at 60 and freezes; B
+     * absorbs the whole 40 remaining (60 + 40 = 100 fits exactly). */
+    struct yetty_ycore_void_result lr = yetty_ygui_layout_compute(root, rect(0, 0, 100, 50));
+    YTEST_REQUIRE_OK(test, lr);
+
+    struct yetty_ycore_rectangle_result ar = yetty_ygui_widget_rect(ra.value);
+    YTEST_REQUIRE_OK(test, ar);
+    struct yetty_ycore_rectangle_result br = yetty_ygui_widget_rect(rb.value);
+    YTEST_REQUIRE_OK(test, br);
+    YTEST_CHECK_NEAR(test, ar.value.max.x - ar.value.min.x, 60.0f, LAYOUT_TOL);
+    YTEST_CHECK_NEAR(test, br.value.max.x - br.value.min.x, 40.0f, LAYOUT_TOL);
+    YTEST_CHECK_NEAR(test, br.value.min.x, 60.0f, LAYOUT_TOL);
+
+    yetty_ygui_widget_destroy(root);
+}
+
+/* An absolutely-positioned child is placed at (pos_x, pos_y) in the content box
+ * at its own size and takes no part in flex flow — its in-flow siblings lay out
+ * as if it were not there. */
+static void test_absolute_positioning(struct ytest *test)
+{
+    struct yetty_yclass_object_ptr_result r =
+        yetty_ygui_widget_new(yetty_ygui_vbox_class_get().value);
+    YTEST_REQUIRE_OK(test, r);
+    struct yetty_yclass_object *root = r.value;
+
+    struct yetty_yclass_object_ptr_result rabs =
+        yetty_ygui_widget_add(root, yetty_ygui_label_class_get().value);
+    YTEST_REQUIRE_OK(test, rabs);
+    struct yetty_yclass_object_ptr_result rflow =
+        yetty_ygui_widget_add(root, yetty_ygui_label_class_get().value);
+    YTEST_REQUIRE_OK(test, rflow);
+
+    struct yetty_ygui_layout_const_ptr_result labs_res = yetty_ygui_widget_layout_get(rabs.value);
+    YTEST_REQUIRE_OK(test, labs_res);
+    struct yetty_ygui_layout labs = *labs_res.value;
+    labs.absolute = 1;
+    labs.pos_x = 10.0f;
+    labs.pos_y = 20.0f;
+    labs.width = 30.0f;
+    labs.height = 40.0f;
+    yetty_ygui_widget_layout_set(rabs.value, &labs);
+
+    struct yetty_ygui_layout_const_ptr_result lflow_res = yetty_ygui_widget_layout_get(rflow.value);
+    YTEST_REQUIRE_OK(test, lflow_res);
+    struct yetty_ygui_layout lflow = *lflow_res.value;
+    lflow.width = 50.0f;
+    lflow.height = 25.0f;
+    yetty_ygui_widget_layout_set(rflow.value, &lflow);
+
+    struct yetty_ygui_layout_const_ptr_result lp_res = yetty_ygui_widget_layout_get(root);
+    YTEST_REQUIRE_OK(test, lp_res);
+    struct yetty_ygui_layout lp = *lp_res.value;
+    lp.padding_left = lp.padding_right = lp.padding_top = lp.padding_bottom = 0.0f;
+    yetty_ygui_widget_layout_set(root, &lp);
+
+    struct yetty_ycore_void_result lr = yetty_ygui_layout_compute(root, rect(0, 0, 200, 200));
+    YTEST_REQUIRE_OK(test, lr);
+
+    struct yetty_ycore_rectangle_result ar = yetty_ygui_widget_rect(rabs.value);
+    YTEST_REQUIRE_OK(test, ar);
+    YTEST_CHECK_NEAR(test, ar.value.min.x, 10.0f, LAYOUT_TOL);
+    YTEST_CHECK_NEAR(test, ar.value.min.y, 20.0f, LAYOUT_TOL);
+    YTEST_CHECK_NEAR(test, ar.value.max.x - ar.value.min.x, 30.0f, LAYOUT_TOL);
+    YTEST_CHECK_NEAR(test, ar.value.max.y - ar.value.min.y, 40.0f, LAYOUT_TOL);
+
+    /* The in-flow child starts at the content top (y == 0), unaffected by the
+     * absolute sibling that precedes it in the child list. */
+    struct yetty_ycore_rectangle_result fr = yetty_ygui_widget_rect(rflow.value);
+    YTEST_REQUIRE_OK(test, fr);
+    YTEST_CHECK_NEAR(test, fr.value.min.y, 0.0f, LAYOUT_TOL);
+
+    yetty_ygui_widget_destroy(root);
+}
+
+/* A child that is BOTH absolute and hidden must be folded away entirely: the
+ * layout pass must not place it (no new rect) and must not recurse into it.
+ * Regression guard for the pass that once checked `absolute` before `hidden`
+ * and so re-placed hidden absolute overlays. We seed a sentinel rect, mark the
+ * child absolute+hidden with a pos that WOULD move it, run layout, and assert
+ * the rect is untouched. */
+static void test_hidden_absolute_not_placed(struct ytest *test)
+{
+    struct yetty_yclass_object_ptr_result r =
+        yetty_ygui_widget_new(yetty_ygui_vbox_class_get().value);
+    YTEST_REQUIRE_OK(test, r);
+    struct yetty_yclass_object *root = r.value;
+
+    struct yetty_yclass_object_ptr_result rhidden =
+        yetty_ygui_widget_add(root, yetty_ygui_label_class_get().value);
+    YTEST_REQUIRE_OK(test, rhidden);
+
+    /* Seed a distinctive sentinel rect the layout must leave alone. */
+    struct yetty_ycore_rectangle sentinel = rect(3, 7, 33, 47);
+    yetty_ygui_widget_set_rect(rhidden.value, sentinel);
+
+    struct yetty_ygui_layout_const_ptr_result lh_res = yetty_ygui_widget_layout_get(rhidden.value);
+    YTEST_REQUIRE_OK(test, lh_res);
+    struct yetty_ygui_layout lh = *lh_res.value;
+    lh.absolute = 1;
+    lh.hidden = 1;
+    /* A pos/size that differs from the sentinel — if the pass placed it, the
+     * rect would become (100,120)-(150,180) and the asserts below would fail. */
+    lh.pos_x = 100.0f;
+    lh.pos_y = 120.0f;
+    lh.width = 50.0f;
+    lh.height = 60.0f;
+    yetty_ygui_widget_layout_set(rhidden.value, &lh);
+
+    struct yetty_ycore_void_result lr = yetty_ygui_layout_compute(root, rect(0, 0, 200, 200));
+    YTEST_REQUIRE_OK(test, lr);
+
+    struct yetty_ycore_rectangle_result hr = yetty_ygui_widget_rect(rhidden.value);
+    YTEST_REQUIRE_OK(test, hr);
+    /* Rect is exactly the sentinel: layout neither placed nor recursed. */
+    YTEST_CHECK_NEAR(test, hr.value.min.x, sentinel.min.x, LAYOUT_TOL);
+    YTEST_CHECK_NEAR(test, hr.value.min.y, sentinel.min.y, LAYOUT_TOL);
+    YTEST_CHECK_NEAR(test, hr.value.max.x, sentinel.max.x, LAYOUT_TOL);
+    YTEST_CHECK_NEAR(test, hr.value.max.y, sentinel.max.y, LAYOUT_TOL);
+
+    yetty_ygui_widget_destroy(root);
+}
+
+/* wrap == WRAP breaks children onto a new line when they overflow the main
+ * axis; the wrapped child advances on the cross axis by the previous line's
+ * height. */
+static void test_flex_wrap(struct ytest *test)
+{
+    struct yetty_yclass_object_ptr_result r =
+        yetty_ygui_widget_new(yetty_ygui_hbox_class_get().value);
+    YTEST_REQUIRE_OK(test, r);
+    struct yetty_yclass_object *root = r.value;
+
+    struct yetty_yclass_object *kids[3];
+    for (int i = 0; i < 3; ++i) {
+        struct yetty_yclass_object_ptr_result kr =
+            yetty_ygui_widget_add(root, yetty_ygui_label_class_get().value);
+        YTEST_REQUIRE_OK(test, kr);
+        kids[i] = kr.value;
+        struct yetty_ygui_layout_const_ptr_result kl_res = yetty_ygui_widget_layout_get(kids[i]);
+        YTEST_REQUIRE_OK(test, kl_res);
+        struct yetty_ygui_layout kl = *kl_res.value;
+        kl.width = 40.0f;
+        kl.height = 20.0f;
+        yetty_ygui_widget_layout_set(kids[i], &kl);
+    }
+
+    struct yetty_ygui_layout_const_ptr_result lp_res = yetty_ygui_widget_layout_get(root);
+    YTEST_REQUIRE_OK(test, lp_res);
+    struct yetty_ygui_layout lp = *lp_res.value;
+    lp.direction = YETTY_YGUI_FLEX_ROW;
+    lp.gap = 0.0f;
+    lp.wrap = YETTY_YGUI_WRAP_WRAP;
+    lp.padding_left = lp.padding_right = lp.padding_top = lp.padding_bottom = 0.0f;
+    yetty_ygui_widget_layout_set(root, &lp);
+
+    /* 100 wide: 40+40 fit on line 1, the third (120 total) wraps to line 2. */
+    struct yetty_ycore_void_result lr = yetty_ygui_layout_compute(root, rect(0, 0, 100, 100));
+    YTEST_REQUIRE_OK(test, lr);
+
+    struct yetty_ycore_rectangle_result r0 = yetty_ygui_widget_rect(kids[0]);
+    struct yetty_ycore_rectangle_result r1 = yetty_ygui_widget_rect(kids[1]);
+    struct yetty_ycore_rectangle_result r2 = yetty_ygui_widget_rect(kids[2]);
+    YTEST_REQUIRE_OK(test, r0);
+    YTEST_REQUIRE_OK(test, r1);
+    YTEST_REQUIRE_OK(test, r2);
+    /* Line 1: kids 0 and 1 at y == 0, side by side. */
+    YTEST_CHECK_NEAR(test, r0.value.min.y, 0.0f, LAYOUT_TOL);
+    YTEST_CHECK_NEAR(test, r1.value.min.y, 0.0f, LAYOUT_TOL);
+    YTEST_CHECK_NEAR(test, r1.value.min.x, 40.0f, LAYOUT_TOL);
+    /* Line 2: kid 2 wrapped down one line (height 20) and back to x == 0. */
+    YTEST_CHECK_NEAR(test, r2.value.min.x, 0.0f, LAYOUT_TOL);
+    YTEST_CHECK_NEAR(test, r2.value.min.y, 20.0f, LAYOUT_TOL);
+
+    yetty_ygui_widget_destroy(root);
+}
+
+/* align-self overrides the parent's cross alignment for one child, and a
+ * per-side margin offsets the child's box on both axes. */
+static void test_align_self_and_margin(struct ytest *test)
+{
+    struct yetty_yclass_object_ptr_result r =
+        yetty_ygui_widget_new(yetty_ygui_hbox_class_get().value);
+    YTEST_REQUIRE_OK(test, r);
+    struct yetty_yclass_object *root = r.value;
+
+    struct yetty_yclass_object_ptr_result ka =
+        yetty_ygui_widget_add(root, yetty_ygui_label_class_get().value);
+    YTEST_REQUIRE_OK(test, ka);
+
+    struct yetty_ygui_layout_const_ptr_result la_res = yetty_ygui_widget_layout_get(ka.value);
+    YTEST_REQUIRE_OK(test, la_res);
+    struct yetty_ygui_layout la = *la_res.value;
+    la.width = 40.0f;
+    la.height = 30.0f;
+    la.align_self = YETTY_YGUI_ALIGN_SELF_END; /* bottom in a row */
+    la.margin_left = 15.0f;                    /* main-axis lead offset */
+    yetty_ygui_widget_layout_set(ka.value, &la);
+
+    struct yetty_ygui_layout_const_ptr_result lp_res = yetty_ygui_widget_layout_get(root);
+    YTEST_REQUIRE_OK(test, lp_res);
+    struct yetty_ygui_layout lp = *lp_res.value;
+    lp.direction = YETTY_YGUI_FLEX_ROW;
+    lp.align = YETTY_YGUI_ALIGN_START; /* parent default the child overrides */
+    lp.gap = 0.0f;
+    lp.padding_left = lp.padding_right = lp.padding_top = lp.padding_bottom = 0.0f;
+    yetty_ygui_widget_layout_set(root, &lp);
+
+    struct yetty_ycore_void_result lr = yetty_ygui_layout_compute(root, rect(0, 0, 200, 100));
+    YTEST_REQUIRE_OK(test, lr);
+
+    struct yetty_ycore_rectangle_result ar = yetty_ygui_widget_rect(ka.value);
+    YTEST_REQUIRE_OK(test, ar);
+    /* margin_left pushes the main-axis start to x == 15. */
+    YTEST_CHECK_NEAR(test, ar.value.min.x, 15.0f, LAYOUT_TOL);
+    /* align-self END puts the 30-tall box at the bottom of the 100 cross:
+     * y == 100 - 30 == 70 (not 0, which the parent's START would give). */
+    YTEST_CHECK_NEAR(test, ar.value.min.y, 70.0f, LAYOUT_TOL);
+
+    yetty_ygui_widget_destroy(root);
+}
+
 int main(void)
 {
     struct ytest test = ytest_begin("ygui_layout");
     YTEST_RUN(&test, test_hbox_two_children);
     YTEST_RUN(&test, test_vbox_flex_grow);
     YTEST_RUN(&test, test_padding);
+    YTEST_RUN(&test, test_flex_shrink_min_clamp_redistributes);
+    YTEST_RUN(&test, test_absolute_positioning);
+    YTEST_RUN(&test, test_hidden_absolute_not_placed);
+    YTEST_RUN(&test, test_flex_wrap);
+    YTEST_RUN(&test, test_align_self_and_margin);
     YTEST_RUN(&test, test_clickable_state_machine);
     YTEST_RUN(&test, test_widget_paint_emits_real_prims);
     return ytest_end(&test);


### PR DESCRIPTION
- layout.c: full CSS-flexbox-shaped engine (flex-wrap, align-self, per-side margins, shrink weighted by flex_shrink*flex_basis, min/max clamp with redistribution); hidden children folded before absolute placement; margin-aware cross-axis CENTER alignment.
- widget.c: typed per-slot super helpers (on_press/release/motion/scroll), typed mixin dispatch helpers, layout_set dirty routing + no-op guard, super_void/super_int allowlist guards.
- yclass codegen: authoritative-type fix so a module's owning .c wins over stale reproduced header copies pulled in via sibling includes.
- tests: slot precedence, mixin dispatch, flex shrink/clamp redistribution, absolute positioning, hidden+absolute guard, flex-wrap, align-self+margin, and widget-paint real-primitive emission.