### PR TITLE
cpython: MSVC fix — _off_t needs <sys/types.h>

### DIFF
--- a/src/cpython/src/runtime/Python.h
+++ b/src/cpython/src/runtime/Python.h
@@ -24,8 +24,9 @@
  * names, and /std:c11 mode hides the POSIX aliases (__STDC__ is 1, so the
  * UCRT suppresses its non-standard-name declarations). Map the names the
  * vendored file tokenizer uses (fileno/fdopen/lseek/read and the off_t it
- * casts to). _off_t comes from <corecrt.h>, already in scope via <stdio.h>. */
+ * casts to). */
 #include <io.h>
+#include <sys/types.h> /* _off_t */
 #define off_t _off_t
 #define fileno _fileno
 #define fdopen _fdopen


### PR DESCRIPTION
Fixes the `build-windows-ytrace-release` failure on tag `yetty-0.2.61`:

```
src\cpython\...\tokenizer\file_tokenizer.c(154): error C2065: '_off_t': undeclared identifier
```

The MSVC branch of the shadow `Python.h` maps `off_t` to `_off_t`, but `_off_t` is declared in `<sys/types.h>` (not `<corecrt.h>`). One-line fix: include `<sys/types.h>` in that branch.

Everything else in the yetty_cpython MSVC build (parser.c, pegen, lexer, all tokenizers, the fileno/fdopen/lseek/read/_dup mappings) compiled clean in the failed run — this was the sole error. Verified on Linux: full desktop build green, py-parse and yfspy smoke-tested.