### PR TITLE
clang-format sweep: ybrowser, yplot, yplatform/webasm, yai, browser-ui

### DIFF
--- a/src/yetty/ybrowser/ybrowser-box.c
+++ b/src/yetty/ybrowser/ybrowser-box.c
@@ -2424,8 +2424,8 @@ static struct yetty_ycore_void_result walk(struct yetty_ylexbor *r, lxb_dom_node
                     parse_html_dimension_attr((const char *)iframe_aw, iframe_alen, &definite_w,
                                               &pct_w);
                 }
-                const lxb_char_t *iframe_ah =
-                    lxb_dom_element_get_attribute(el, (const lxb_char_t *)"height", 6, &iframe_alen);
+                const lxb_char_t *iframe_ah = lxb_dom_element_get_attribute(
+                    el, (const lxb_char_t *)"height", 6, &iframe_alen);
                 if (iframe_ah && iframe_alen > 0) {
                     parse_html_dimension_attr((const char *)iframe_ah, iframe_alen, &definite_h,
                                               &pct_h);

--- a/src/yetty/ybrowser/ybrowser-internal.h
+++ b/src/yetty/ybrowser/ybrowser-internal.h
@@ -760,7 +760,7 @@ struct yetty_ylexbor_kv_store {
 #define YETTY_YLEXBOR_CONSOLE_CAP 2000
 
 struct yetty_ylexbor_console_entry {
-    int level; /* enum yetty_ylexbor_console_level */
+    int level;  /* enum yetty_ylexbor_console_level */
     char *text; /* owned */
 };
 

--- a/src/yetty/ybrowser/ybrowser-layout.c
+++ b/src/yetty/ybrowser/ybrowser-layout.c
@@ -2915,8 +2915,8 @@ static struct float_result layout_grid(struct yetty_ylexbor *r, uint32_t idx, fl
         } else if (self->grid_tracks[c].is_auto) {
             fixed_sum += auto_w[c];
         } else if (self->grid_tracks[c].is_pct) {
-            float track_w = self->grid_tracks[c].value * 0.01f * content_width +
-                            self->grid_tracks[c].offset;
+            float track_w =
+                self->grid_tracks[c].value * 0.01f * content_width + self->grid_tracks[c].offset;
             fixed_sum += track_w > 0.0f ? track_w : 0.0f;
         } else {
             fixed_sum += self->grid_tracks[c].value;
@@ -2937,8 +2937,8 @@ static struct float_result layout_grid(struct yetty_ylexbor *r, uint32_t idx, fl
         } else if (self->grid_tracks[c].is_auto) {
             col_w[c] = auto_w[c];
         } else if (self->grid_tracks[c].is_pct) {
-            col_w[c] = self->grid_tracks[c].value * 0.01f * content_width +
-                       self->grid_tracks[c].offset;
+            col_w[c] =
+                self->grid_tracks[c].value * 0.01f * content_width + self->grid_tracks[c].offset;
             if (col_w[c] < 0.0f) {
                 col_w[c] = 0.0f;
             }

--- a/src/yetty/ybrowser/ybrowser.c
+++ b/src/yetty/ybrowser/ybrowser.c
@@ -806,14 +806,12 @@ static struct yetty_ycore_void_result resolve_iframes(struct yetty_ylexbor *r)
                 continue;
             }
             /* `about:`/`javascript:` iframes have no fetchable document. */
-            if (strncmp(absolute, "about:", 6) == 0 ||
-                strncmp(absolute, "javascript:", 11) == 0) {
+            if (strncmp(absolute, "about:", 6) == 0 || strncmp(absolute, "javascript:", 11) == 0) {
                 free(absolute);
                 continue;
             }
-            struct yetty_ybrowser_request request = {.url = absolute,
-                                                     .kind = YETTY_YBROWSER_REQUEST_DOCUMENT,
-                                                     .referer = r->base_url};
+            struct yetty_ybrowser_request request = {
+                .url = absolute, .kind = YETTY_YBROWSER_REQUEST_DOCUMENT, .referer = r->base_url};
             struct yetty_ybrowser_response response = {0};
             struct yetty_ycore_void_result fetch_res =
                 yetty_ybrowser_fetch(r->loader, &request, &response);
@@ -832,13 +830,13 @@ static struct yetty_ycore_void_result resolve_iframes(struct yetty_ylexbor *r)
             continue;
         }
 
-        int content_w = (int)(b->w - b->border_left - b->border_right - b->padding_left -
-                              b->padding_right);
+        int content_w =
+            (int)(b->w - b->border_left - b->border_right - b->padding_left - b->padding_right);
         if (content_w < 1) {
             content_w = (int)b->w;
         }
-        int content_h = (int)(b->h - b->border_top - b->border_bottom - b->padding_top -
-                              b->padding_bottom);
+        int content_h =
+            (int)(b->h - b->border_top - b->border_bottom - b->padding_top - b->padding_bottom);
         if (content_h < 1) {
             content_h = (int)b->h;
         }

--- a/src/yetty/yplatform/yplatform/webasm.c
+++ b/src/yetty/yplatform/yplatform/webasm.c
@@ -136,8 +136,7 @@ static struct yetty_ycore_void_result webasm_platform_init(struct yetty_yclass_o
         WGPUInstanceFeatureName_TimedWaitAny,
     };
     WGPUInstanceDescriptor instance_desc = {0};
-    instance_desc.requiredFeatureCount =
-        sizeof(instance_features) / sizeof(instance_features[0]);
+    instance_desc.requiredFeatureCount = sizeof(instance_features) / sizeof(instance_features[0]);
     instance_desc.requiredFeatures = instance_features;
     WGPUInstance instance = wgpuCreateInstance(&instance_desc);
     if (!instance) {

--- a/src/yetty/yplot/yplot.c
+++ b/src/yetty/yplot/yplot.c
@@ -370,9 +370,10 @@ static struct yetty_ycore_void_result yplot_add_label(struct yetty_ydraw_drawabl
  * plot rect (bounds_* already shrunk by the reserved margins) and the axis
  * ranges; `figure_max_x` is the pre-inset right edge, used to keep the last
  * x label from spilling past the figure. */
-static struct yetty_ycore_void_result yplot_emit_axis_labels(
-    struct yetty_ydraw_drawable_list *list, const struct yetty_yplot_uniforms *u,
-    const struct yplot_label_plan *plan, float figure_max_x)
+static struct yetty_ycore_void_result yplot_emit_axis_labels(struct yetty_ydraw_drawable_list *list,
+                                                             const struct yetty_yplot_uniforms *u,
+                                                             const struct yplot_label_plan *plan,
+                                                             float figure_max_x)
 {
     float plot_x = u->bounds_x;
     float plot_y = u->bounds_y;
@@ -460,10 +461,12 @@ static uint32_t yplot_color_swap_rb(uint32_t color)
  * outside the plot rect (the shader discards those fragments), so no draw-order
  * juggling against the plot is needed. `margin_left` is the x of the strip's
  * left edge (the inset plot's right edge). */
-static struct yetty_ycore_void_result yplot_emit_legend(
-    struct yetty_ydraw_drawable_list *list, const struct yetty_yplot_uniforms *u,
-    const struct yplot_label_plan *plan, float margin_left,
-    const struct yplot_legend_entry *entries, size_t count)
+static struct yetty_ycore_void_result yplot_emit_legend(struct yetty_ydraw_drawable_list *list,
+                                                        const struct yetty_yplot_uniforms *u,
+                                                        const struct yplot_label_plan *plan,
+                                                        float margin_left,
+                                                        const struct yplot_legend_entry *entries,
+                                                        size_t count)
 {
     float font_size = plan->font_size;
     float pad = font_size * 0.4f;
@@ -492,8 +495,8 @@ static struct yetty_ycore_void_result yplot_emit_legend(
         if (entries[i].name && entries[i].name[0]) {
             float text_x = swatch_x + swatch_width + gap;
             float baseline = row_center + font_size * 0.35f;
-            struct yetty_ycore_void_result text_res = yplot_add_label(
-                list, text_x, baseline, entries[i].name, font_size, 0xFFE4E5E0u);
+            struct yetty_ycore_void_result text_res =
+                yplot_add_label(list, text_x, baseline, entries[i].name, font_size, 0xFFE4E5E0u);
             YETTY_RETURN_IF_ERR(yetty_ycore_void, text_res, "yplot: legend name");
         }
     }
@@ -528,7 +531,8 @@ static struct yetty_ydraw_drawable_list_result yplot_emit_prim(
     if (plan.enabled && legend_entries && legend_count >= 2) {
         legend_margin = yplot_legend_margin(legend_entries, legend_count, plan.font_size);
         float plot_width_left = u.bounds_w - plan.left_margin - legend_margin;
-        if (legend_margin > 0.0f && legend_margin <= u.bounds_w * 0.4f && plot_width_left >= 20.0f) {
+        if (legend_margin > 0.0f && legend_margin <= u.bounds_w * 0.4f &&
+            plot_width_left >= 20.0f) {
             show_legend = true;
         } else {
             legend_margin = 0.0f;

--- a/tools/ai/yai/main.c
+++ b/tools/ai/yai/main.c
@@ -4125,9 +4125,8 @@ static struct yetty_ycore_void_result usage_render_plot(struct yai_app *app)
     char heading[96];
     snprintf(heading, sizeof(heading), "tokens consumed over time (x: %s, y: cumulative total)",
              use_minutes ? "minutes" : "seconds");
-    struct yetty_ycore_int_result plot_res =
-        yai_render_line_plot(&app->renderer, grid, YAI_USAGE_PLOT_GRID, 0.0f, x_max, 0.0f, y_max,
-                             heading);
+    struct yetty_ycore_int_result plot_res = yai_render_line_plot(
+        &app->renderer, grid, YAI_USAGE_PLOT_GRID, 0.0f, x_max, 0.0f, y_max, heading);
     YETTY_RETURN_IF_ERR(yetty_ycore_void, plot_res, "usage plot: render");
     return YETTY_OK_VOID();
 }
@@ -4832,7 +4831,8 @@ void yai_usage_record_sample(struct yai_app *app)
         app->usage_sample_count = kept;
     }
     long now_ms = yai_monotonic_ms();
-    double elapsed = app->session_start_ms ? (double)(now_ms - app->session_start_ms) / 1000.0 : 0.0;
+    double elapsed =
+        app->session_start_ms ? (double)(now_ms - app->session_start_ms) / 1000.0 : 0.0;
     if (elapsed < 0.0) {
         elapsed = 0.0;
     }
@@ -4840,8 +4840,8 @@ void yai_usage_record_sample(struct yai_app *app)
     sample->elapsed_seconds = elapsed;
     /* "Consumed" = everything the model processed this session: fresh input
      * and output plus the cache reads/writes (the bulk of the cost). */
-    sample->total_tokens = app->usage.input + app->usage.output + app->usage.cache_read +
-                           app->usage.cache_creation;
+    sample->total_tokens =
+        app->usage.input + app->usage.output + app->usage.cache_read + app->usage.cache_creation;
 }
 
 /* Ctrl-D on an empty line: the first press only arms a confirmation

--- a/tools/ai/yai/render.c
+++ b/tools/ai/yai/render.c
@@ -1334,9 +1334,7 @@ struct yetty_ycore_int_result yai_render_line_plot(struct yai_renderer *renderer
         .flags = YETTY_YPLOT_FLAG_GRID | YETTY_YPLOT_FLAG_AXES | YETTY_YPLOT_FLAG_LABELS,
     };
     struct yetty_yplot_buffer_input buffer = {
-        .samples = samples,
-        .count = count,
-        .color = 0, /* palette default (mint) */
+        .samples = samples, .count = count, .color = 0, /* palette default (mint) */
     };
     struct yetty_ydraw_drawable_list_result render_res =
         yetty_yplot_render_with_buffers("", 0, &buffer, 1, &config);

--- a/tools/ybrowser/browser-ui.c
+++ b/tools/ybrowser/browser-ui.c
@@ -68,13 +68,13 @@
  * pipeline (see pack_rgba in ybrowser-paint.c). The level colors reuse the
  * brand palette; warn/error are functional severity colors the brand set does
  * not define (a console must read amber for warnings and red for errors). */
-#define CONSOLE_TEXT 0xFFE4E5E0u    /* #E0E5E4 brand text-primary — log/info */
-#define CONSOLE_MUTED 0xFF626155u   /* #556162 brand text-muted — debug */
-#define CONSOLE_WARN 0xFF4DA3E5u    /* #E5A34D amber */
-#define CONSOLE_ERROR 0xFF4D57E5u   /* #E5574D red */
-#define CONSOLE_INPUT 0xFFA8A79Fu   /* #9FA7A8 brand text-secondary — typed input */
-#define CONSOLE_ACCENT 0xFF92A86Bu  /* #6BA892 brand accent — prompt/marker glyphs */
-#define CONSOLE_RESULT 0xFFA5C574u  /* #74C5A5 brand accent-bright — eval result */
+#define CONSOLE_TEXT 0xFFE4E5E0u   /* #E0E5E4 brand text-primary — log/info */
+#define CONSOLE_MUTED 0xFF626155u  /* #556162 brand text-muted — debug */
+#define CONSOLE_WARN 0xFF4DA3E5u   /* #E5A34D amber */
+#define CONSOLE_ERROR 0xFF4D57E5u  /* #E5574D red */
+#define CONSOLE_INPUT 0xFFA8A79Fu  /* #9FA7A8 brand text-secondary — typed input */
+#define CONSOLE_ACCENT 0xFF92A86Bu /* #6BA892 brand accent — prompt/marker glyphs */
+#define CONSOLE_RESULT 0xFFA5C574u /* #74C5A5 brand accent-bright — eval result */
 #define CONSOLE_FONT_SIZE 13.0f
 #define DEVTOOLS_HEIGHT 300.0f
 
@@ -369,8 +369,9 @@ static int build_ui(struct app *a);
 static void dt_layout(struct yetty_yclass_object *w, float height, float flex_grow, float pad_x,
                       float pad_y);
 static void dt_set_hidden(struct yetty_yclass_object *w, int hidden);
-static struct yetty_yclass_object *dt_add_label(struct yetty_yclass_object *parent, const char *text,
-                                                struct yetty_ycore_rgba color, float font_size);
+static struct yetty_yclass_object *dt_add_label(struct yetty_yclass_object *parent,
+                                                const char *text, struct yetty_ycore_rgba color,
+                                                float font_size);
 static void toggle_devtools(struct app *a);
 static void switch_devtools_tab(struct app *a, int tab);
 static void dom_tree_rebuild(struct app *a);
@@ -1641,9 +1642,9 @@ static int dom_tree_visit(void *user, int depth, int has_children, const char *l
         }
         builder->parent_at_depth[depth + 1] = node_res.value;
     } else {
-        struct yetty_ycore_rgba color = label[0] == '"'
-                                            ? (struct yetty_ycore_rgba){159, 167, 168, 255} /* text */
-                                            : (struct yetty_ycore_rgba){116, 197, 165, 255}; /* elem */
+        struct yetty_ycore_rgba color =
+            label[0] == '"' ? (struct yetty_ycore_rgba){159, 167, 168, 255}  /* text */
+                            : (struct yetty_ycore_rgba){116, 197, 165, 255}; /* elem */
         struct yetty_yclass_object *leaf = dt_add_label(parent, label, color, CONSOLE_FONT_SIZE);
         if (leaf) {
             /* Explicit row height: labels report no intrinsic height to the flex
@@ -1754,8 +1755,8 @@ static void console_add_wrapped(struct app *a, const char *marker, const char *t
         line[copy_len] = '\0';
         err_ok(yetty_ygui_rich_add_line(a->console_log));
         if (first_segment && marker && marker[0]) {
-            err_ok(
-                yetty_ygui_rich_add_span(a->console_log, marker, CONSOLE_FONT_SIZE, CONSOLE_ACCENT));
+            err_ok(yetty_ygui_rich_add_span(a->console_log, marker, CONSOLE_FONT_SIZE,
+                                            CONSOLE_ACCENT));
         }
         err_ok(yetty_ygui_rich_add_span(a->console_log, line, CONSOLE_FONT_SIZE, color));
         first_segment = 0;
@@ -1915,8 +1916,7 @@ static int pump_active(struct app *a)
             a->pending_render = 1;
         }
         /* New page console.* output while DevTools is open → refresh the log. */
-        if (a->devtools_open &&
-            yetty_ylexbor_console_total(t->engine) != a->console_seen_total) {
+        if (a->devtools_open && yetty_ylexbor_console_total(t->engine) != a->console_seen_total) {
             a->console_dirty = 1;
             a->pending_render = 1;
         }


### PR DESCRIPTION
Format-only output of `qa-tools/refactoring/code-format/apply-format.py` — 9 files of pre-existing drift, no behavior changes. Kept separate from the #529 fix so blame stays useful.