### PR TITLE
yvterm: render programming ligatures grid-native, per-cell

### DIFF
--- a/demo/scripts/harfbuzz/ligatures.sh
+++ b/demo/scripts/harfbuzz/ligatures.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # HarfBuzz programming-ligature demo.
 #
-# The terminal grid font cannot shape, so a run of operator characters that
-# forms a programming ligature (=>, !=, ===, ...) is suppressed on the grid
-# and re-drawn as a single shaped glyph through the SDF free-position path
-# against the bundled Fira Code face. Ordinary text stays on the crisp MSDF
-# grid; only the ligature spans are shaped.
+# A programming ligature (=>, !=, ===, ...) is shaped through Fira Code's calt
+# tables, which keep one glyph per cell — each operator character is substituted
+# with a ligature-piece glyph that tiles with its neighbours. Each piece is
+# drawn directly by the grid shader as an ordinary one-cell glyph from the
+# bundled Fira Code raster face. Ordinary text stays on the crisp MSDF grid;
+# only the ligature spans use the Fira Code face.
 #
 # Needs a build with YETTY_ENABLE_LIB_HARFBUZZ=ON. Without it the operators
 # render as individual grid glyphs (no ligature) — still correct, just plain.

--- a/docs/text-shaping.md
+++ b/docs/text-shaping.md
@@ -254,32 +254,47 @@ Phasing:
     binder-supplied `__NS___texture_region` vec4, exactly like `msdf-font.wgsl`.
     The rolling-row scroll anchors each shaped row for O(1) scroll. Verified
     live for all five families via `demo/scripts/harfbuzz/`.
-- **Phase 2 — programming ligatures (Fira Code `=>`, `!=`, `===`, …) — DONE.**
-  Rather than extend the grid cell format/shader to carry arbitrary-width
-  ligature spans (the grid glyph sampler hard-clips each glyph to its cell and
-  supports only a fixed 2-cell wide-glyph spill), ligatures reuse the same
-  suppress-then-redraw machinery as complex scripts: the covered cells are
-  suppressed on the grid and the ligature is drawn as one shaped glyph through
-  the SDF free-position path against a bundled ligature face. Details:
+- **Phase 2 — programming ligatures (Fira Code `=>`, `!=`, `===`, …) — DONE,
+  grid-native.** A monospace ligature font does NOT collapse an operator run to
+  one wide glyph. Fira Code's `calt` keeps **one glyph per input cell** and
+  substitutes each character with a ligature-*piece* glyph that tiles with its
+  neighbours (`->` shapes to an extended-bar glyph + an arrowhead glyph, each
+  one cell wide; `===` to three pieces). Every entry in the table shapes
+  one-glyph-per-cell (verified). So each covered cell simply gets its own
+  substituted glyph from the ligature face — an ordinary width-1 grid glyph —
+  drawn in the grid's own pass, no free-position SDF overlay and no wide/spill
+  glyph. Details:
   - A HarfBuzz-free, deterministic ligature table (`yfont/ligature.c`,
     `yetty_yfont_ligature_length_at`) — punctuation-only, so it never fires on
     ordinary words/numbers. A shared cell-level wrapper
     (`yvterm/ligature-cells.h`, `yetty_yvterm_ligature_run_length`) combines it
     with a shapeability check (single-width, unconcealed, mark-free cells).
-  - `vterm_pack_line` suppresses a ligature span's grid glyphs; the SDF layer's
-    `shape_row_ligatures` shapes the same span (both call the shared wrapper, so
-    they cover identical cells with no cross-talk) against the bundled Fira Code
-    face (`assets/fonts/FiraCode-Regular.ttf`, SIL OFL), loaded via the same
-    `sdf_face_load_or_get` as the complex-script faces.
-  - The face is width-scaled (`get_advance` → `font_size = cell_width·base/adv`)
-    so one character advance equals the grid cell, making a ligature span its
-    cells exactly and keeping following grid text cell-aligned. The ASCII-only
-    ligature table never overlaps the complex-script codepoint ranges, so the
-    two shaping passes are disjoint. Verified live via
-    `demo/scripts/harfbuzz/ligatures.sh`; table pinned by `yfont_ligature` test.
+  - A bundled Fira Code face (`assets/fonts/FiraCode-Regular.ttf`, SIL OFL) is
+    loaded as a dedicated grid **raster face** (`vterm.c`
+    `vterm_load_ligature_face`, face slot 1). It is sized so one character
+    advance equals the cell width (`ms-raster-font.c` `size_to_cell_width`), so
+    each ligature piece fills exactly one cell and following text stays aligned.
+  - The grid ms-raster-font gained a `get_glyph_index_ligature` op: it shapes the
+    operator run through the face's GSUB/calt tables with HarfBuzz (standalone
+    FT↔HB over the SFNT tables, same bridge as the SDF backend), requires the
+    output to be one glyph per cell, rasterizes each component gid at width 1
+    (keyed by gid), and returns the per-cell atlas slots. Cached by the codepoint
+    sequence so the steady state (the grid re-packs every visible row each frame)
+    is a linear-scan hit with no reshaping.
+  - `vterm_pack_line` calls that op at the start of a run and assigns each covered
+    cell its own component glyph (ordinary width-1 cell, ligature face). No second
+    pass, no per-face binder namespace, no width-scaling at draw time — and
+    because each ligature piece is an ordinary grid glyph, the ligature inverts
+    under the block cursor, punches out under selection, and scrolls with the
+    rolling-row ring for free, which the old SDF-overlay path did not do.
+  - The ASCII-only ligature table never overlaps the complex-script codepoint
+    ranges, so ligatures and the complex-script SDF pass stay disjoint. Verified
+    live via `demo/scripts/harfbuzz/ligatures.sh`; table pinned by
+    `yfont_ligature` test.
   - Gated on `YETTY_ENABLE_LIB_HARFBUZZ` like the rest of the track (now ON by
-    default, so ligatures are on for every build). A runtime on/off config key
-    to let users disable them is a follow-up.
+    default, so ligatures are on for every build). Without the shaper the grid
+    face is never loaded and the operator characters render individually. A
+    runtime on/off config key to let users disable them is a follow-up.
 
 If Phase 1's webasm spike fails to link, the fallback is to gate
 `YETTY_ENABLE_LIB_HARFBUZZ` OFF on webasm (complex scripts fall back to the
@@ -309,11 +324,15 @@ override.
    windows are published in the `lib-harfbuzz-8.5.0-1` release, so the
    cache-first fetch resolves everywhere. Desktop, `yetty.wasm`, and android
    arm64-v8a were all built locally with it on. (#617)
-5. **Programming-ligature shaping on the terminal grid** — DONE (Phase 2). The
-   grid glyph sampler hard-clips glyphs to their cell, so instead of widening
-   the cell format, ligature spans are suppressed on the grid and drawn as one
-   shaped glyph via the SDF free-position path against a bundled Fira Code face
-   (`yfont/ligature.c` table + `yvterm/ligature-cells.h` shared decision +
-   `shape_row_ligatures`). Width-scaled to the cell so spans align. Verified
-   live (`demo/scripts/harfbuzz/ligatures.sh`); table pinned by the
-   `yfont_ligature` test. (#618)
+5. **Programming-ligature shaping on the terminal grid** — DONE (Phase 2),
+   grid-native. Fira Code keeps one substituted glyph per input cell (its calt
+   pieces tile into the ligature), so each covered cell gets its own ordinary
+   width-1 component glyph from a dedicated Fira Code grid raster face, drawn by
+   the grid shader itself — not through the SDF free-position path. The face is
+   sized so one advance equals the cell (`ms-raster-font.c`
+   `get_glyph_index_ligature` returns per-cell slots + `size_to_cell_width`);
+   `vterm_pack_line` assigns each cell its component glyph (`yfont/ligature.c`
+   table + `yvterm/ligature-cells.h` shared decision). One pass, and the
+   ligature inverts/selects/scrolls as ordinary grid text. Verified live
+   (`demo/scripts/harfbuzz/ligatures.sh`); table pinned by the `yfont_ligature`
+   test.

--- a/include/yetty/yfont/ms-font.h
+++ b/include/yetty/yfont/ms-font.h
@@ -83,6 +83,23 @@ struct yetty_yfont_ms_font_ops {
      * error result for an unknown glyph_index. */
     struct uint32_result (*get_codepoint)(struct yetty_yfont_ms_font *self, uint32_t glyph_index);
 
+    /* Shape a programming-ligature codepoint sequence through the face's
+     * OpenType GSUB/calt tables and rasterize its per-cell component glyphs.
+     * Monospace ligature fonts (Fira Code) keep one glyph per input cell — the
+     * calt substitutes each character with a ligature-piece glyph that tiles
+     * with its neighbours to form the ligature (e.g. `->` becomes an extended
+     * bar + an arrowhead, one per cell) — so this fills out_slots[0..count-1]
+     * with the atlas glyph index for each cell and returns the number of cells
+     * filled (== count on success). out_slots must have room for at least
+     * `count` entries. Returns an error result when the run does not shape
+     * cleanly to one glyph per cell (the caller then renders the characters
+     * individually). Optional: left NULL by backends with no live rasterizer +
+     * shaper (the MSDF backend bakes SDFs offline and cannot render a shaped
+     * gid). */
+    struct uint32_result (*get_glyph_index_ligature)(struct yetty_yfont_ms_font *self,
+                                                     const uint32_t *codepoints, size_t count,
+                                                     uint32_t *out_slots);
+
     /* Resize — changes font size, recalculates cell size */
     struct yetty_ycore_void_result (*resize)(struct yetty_yfont_ms_font *self, float font_size);
 

--- a/include/yetty/yfont/ms-raster-font.h
+++ b/include/yetty/yfont/ms-raster-font.h
@@ -21,6 +21,16 @@ struct yetty_font_ms_font_result yetty_yfont_ms_raster_font_create_named(
     struct yetty_yconfig_config *config, const char *font_name, float cell_width,
     float cell_height);
 
+/* Create a programming-ligature face from an explicit font name (e.g.
+ * "FiraCode"). Unlike the range-face create above, this face is sized so one
+ * character advance equals cell_width (rather than the glyph line-box filling
+ * cell_height), so a ligature that shapes to a single glyph spans exactly its
+ * N cells and following grid text stays cell-aligned. Its get_glyph_index_ligature
+ * op is the only entry point used — it is not part of the codepoint routing. */
+struct yetty_font_ms_font_result yetty_yfont_ms_raster_font_create_ligature(
+    struct yetty_yconfig_config *config, const char *font_name, float cell_width,
+    float cell_height);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/yetty/yfont/ms-raster-font.c
+++ b/src/yetty/yfont/ms-raster-font.c
@@ -4,6 +4,7 @@
 
 #include <yetty/yfont/ms-raster-font.h>
 #include <yetty/yfont/ms-font.h>
+#include <yetty/yfont/font.h> /* YETTY_YFONT_LIGATURE_MAX_LEN */
 #include <yetty/yrender/gpu-resource-set.h>
 #include <yetty/yconfig/config.h>
 #include <yetty/ycore/types.h>
@@ -14,7 +15,11 @@
 
 #include <ft2build.h>
 #include FT_FREETYPE_H
-#include FT_TRUETYPE_TABLES_H
+#include FT_TRUETYPE_TABLES_H /* FT_Load_Sfnt_Table — feeds tables to HarfBuzz */
+
+#ifdef YETTY_ENABLE_LIB_HARFBUZZ
+#include <hb.h>
+#endif
 
 #include <limits.h>
 #include <stdlib.h>
@@ -70,6 +75,18 @@ struct yetty_yfont_cluster_slot {
     uint32_t slot;
 };
 
+/* Cache entry for a shaped programming ligature. A monospace ligature font
+ * keeps one glyph per input cell (the calt substitutes each character with a
+ * ligature-piece glyph), so `slots[i]` is the atlas slot for cell i of the run.
+ * The key is the codepoint sequence itself, so a repeated ligature (the steady
+ * state — the grid re-packs every visible row each frame) is a tiny linear-scan
+ * hit with no reshaping. Only populated on the dedicated ligature face. */
+struct yetty_yfont_ligature_slot {
+    uint32_t codepoints[YETTY_YFONT_LIGATURE_MAX_LEN];
+    uint8_t count;
+    uint32_t slots[YETTY_YFONT_LIGATURE_MAX_LEN];
+};
+
 struct yetty_yfont_raster_font {
     struct yetty_yfont_ms_font base;
 
@@ -120,6 +137,21 @@ struct yetty_yfont_raster_font {
     size_t cluster_slots_count[4];
     size_t cluster_slots_capacity[4];
 
+    /* Ligature face: size the font so one character advance equals cell_width
+     * (rather than the line box filling cell_height), so a ligature that
+     * shapes to one glyph spans exactly its N cells. Set only on the dedicated
+     * programming-ligature face. */
+    int size_to_cell_width;
+#ifdef YETTY_ENABLE_LIB_HARFBUZZ
+    /* Lazily-built HarfBuzz font (hb_font_t *) over this face's SFNT tables,
+     * plus the gid->slot cache for shaped ligature glyphs. void* so the struct
+     * layout does not depend on the HarfBuzz headers. */
+    void *hb_font;
+    struct yetty_yfont_ligature_slot *ligature_slots;
+    size_t ligature_slot_count;
+    size_t ligature_slot_capacity;
+#endif
+
     int dirty;
 };
 
@@ -133,6 +165,9 @@ static struct uint32_result raster_font_get_glyph_index_styled(struct yetty_yfon
                                                                enum yetty_yfont_ms_style style);
 static struct uint32_result raster_font_get_codepoint(struct yetty_yfont_ms_font *self,
                                                       uint32_t glyph_index);
+static struct uint32_result raster_font_get_glyph_index_ligature(struct yetty_yfont_ms_font *self,
+                                                                 const uint32_t *codepoints,
+                                                                 size_t count, uint32_t *out_slots);
 static struct yetty_ycore_void_result raster_font_resize(struct yetty_yfont_ms_font *self,
                                                          float font_size);
 static struct yetty_ycore_void_result raster_font_load_glyphs(struct yetty_yfont_ms_font *self,
@@ -173,6 +208,10 @@ static void raster_font_grow_atlas(struct yetty_yfont_raster_font *font);
 static struct yetty_ycore_void_result raster_font_set_cell_size(
     struct yetty_yfont_ms_font *self, struct yetty_ycore_pixel_size cell_size);
 
+static struct yetty_font_ms_font_result raster_font_create_named_impl(
+    struct yetty_yconfig_config *config, const char *font_name, float cell_width, float cell_height,
+    int size_to_cell_width);
+
 static const struct yetty_yfont_ms_font_ops raster_font_ops = {
     .destroy = raster_font_destroy,
     .get_cell_size = raster_font_get_cell_size,
@@ -181,6 +220,7 @@ static const struct yetty_yfont_ms_font_ops raster_font_ops = {
     .get_glyph_index_styled = raster_font_get_glyph_index_styled,
     .get_glyph_index_cluster = raster_font_get_glyph_index_cluster,
     .get_codepoint = raster_font_get_codepoint,
+    .get_glyph_index_ligature = raster_font_get_glyph_index_ligature,
     .resize = raster_font_resize,
     .load_glyphs = raster_font_load_glyphs,
     .load_basic_latin = raster_font_load_basic_latin,
@@ -476,6 +516,32 @@ static void raster_font_update_font_size(struct yetty_yfont_raster_font *font)
     }
     for (size_t i = 0; i < font->fallback_count; i++) {
         raster_font_apply_size_to_face(font, font->fallback_faces[i]);
+    }
+
+    /* Ligature face: override the line-box sizing so one character advance
+     * equals the cell width. A monospace ligature's advance is then N cell
+     * widths, so the shaped glyph spans exactly its N cells and following grid
+     * text stays cell-aligned — the same effect the cell grid gives ordinary
+     * glyphs, achieved by matching the reference advance rather than clipping. */
+    if (font->size_to_cell_width) {
+        FT_Set_Pixel_Sizes(regular_face, 0, (FT_UInt)font->cell_height);
+        FT_UInt ref_gid = FT_Get_Char_Index(regular_face, 'M');
+        float advance_px = 0.0f;
+        if (ref_gid && FT_Load_Glyph(regular_face, ref_gid, FT_LOAD_DEFAULT) == 0) {
+            advance_px = (float)regular_face->glyph->advance.x / 64.0f;
+        }
+        if (advance_px > 0.0f) {
+            font->font_size =
+                (uint32_t)(font->cell_width * (float)font->cell_height / advance_px + 0.5f);
+        }
+        if (font->font_size == 0) {
+            font->font_size = (uint32_t)font->cell_height;
+        }
+        for (int i = 0; i < 4; i++) {
+            if (font->ft_faces[i]) {
+                FT_Set_Pixel_Sizes(font->ft_faces[i], 0, font->font_size);
+            }
+        }
     }
 
     /* Recalculate metrics at new size (same typographic-box substitution). */
@@ -990,6 +1056,11 @@ static void raster_font_rasterize_all(struct yetty_yfont_raster_font *font)
         font->cluster_slots_count[i] = 0;       /* stale cluster slots die with the atlas */
         raster_font_add_slot(font, i, 0x20, 0); /* Map space to slot 0 */
     }
+#ifdef YETTY_ENABLE_LIB_HARFBUZZ
+    /* Shaped ligature slots reference atlas positions the reset just cleared —
+     * drop the cache so they re-rasterize on next use at the new cell size. */
+    font->ligature_slot_count = 0;
+#endif
 
     for (int s = 0; s < 4; s++) {
         for (size_t i = 0; i < font->codepoint_slots_count[s]; i++) {
@@ -1006,8 +1077,328 @@ static void raster_font_rasterize_all(struct yetty_yfont_raster_font *font)
     font->dirty = 1;
 }
 
+#ifdef YETTY_ENABLE_LIB_HARFBUZZ
+/* HarfBuzz table-reference callback: hands a raw SFNT table from the FreeType
+ * face to HarfBuzz. Standalone FT<->HB bridge — HarfBuzz reads cmap/GSUB/GDEF
+ * directly from these blobs and never touches FreeType outlines (rasterization
+ * stays with FreeType), so the two libraries are decoupled. */
+static hb_blob_t *raster_font_hb_reference_table(hb_face_t *hb_face, hb_tag_t tag, void *user_data)
+{
+    (void)hb_face;
+    FT_Face ft_face = (FT_Face)user_data;
+    FT_ULong length = 0;
+    if (FT_Load_Sfnt_Table(ft_face, tag, 0, NULL, &length) != 0 || length == 0) {
+        return NULL;
+    }
+    FT_Byte *buffer = malloc(length);
+    if (!buffer) {
+        return NULL;
+    }
+    if (FT_Load_Sfnt_Table(ft_face, tag, 0, buffer, &length) != 0) {
+        free(buffer);
+        return NULL;
+    }
+    return hb_blob_create((const char *)buffer, (unsigned)length, HB_MEMORY_MODE_WRITABLE, buffer,
+                          free);
+}
+
+/* Lazily build (and cache) the HarfBuzz font over the regular face's SFNT
+ * tables. Only GSUB substitution is used (to collapse an operator run to its
+ * ligature glyph id), so the hb scale is irrelevant and left at the default. */
+static hb_font_t *raster_font_hb_font_get(struct yetty_yfont_raster_font *font)
+{
+    if (font->hb_font) {
+        return (hb_font_t *)font->hb_font;
+    }
+    FT_Face ft_face = font->ft_faces[YETTY_YFONT_MS_STYLE_REGULAR];
+    if (!ft_face) {
+        return NULL;
+    }
+    hb_face_t *hb_face = hb_face_create_for_tables(raster_font_hb_reference_table, ft_face, NULL);
+    if (!hb_face) {
+        return NULL;
+    }
+    hb_face_set_index(hb_face, (unsigned)(ft_face->face_index & 0xFFFF));
+    hb_face_set_upem(hb_face, (unsigned)ft_face->units_per_EM);
+    if (hb_face_get_glyph_count(hb_face) == 0) {
+        hb_face_destroy(hb_face);
+        return NULL;
+    }
+    hb_font_t *hb_font = hb_font_create(hb_face);
+    hb_face_destroy(hb_face); /* hb_font retains a reference */
+    if (!hb_font) {
+        return NULL;
+    }
+    font->hb_font = hb_font;
+    return hb_font;
+}
+
+/* Rasterize a shaped glyph id (a ligature component) at a forced width of
+ * `width_cells` cells into the R8 atlas. Mirrors the monochrome path of
+ * raster_font_rasterize_glyph but keys on the gid rather than a codepoint (the
+ * component glyph has no cmap entry) and fixes the slot width. Fira Code's
+ * pieces are each one cell wide, so callers pass width_cells = 1. Ligature
+ * faces are never color. Returns the new slot index. */
+static struct uint32_result raster_font_rasterize_ligature_gid(struct yetty_yfont_raster_font *font,
+                                                               FT_UInt gid, uint32_t width_cells)
+{
+    FT_Face face = font->ft_faces[YETTY_YFONT_MS_STYLE_REGULAR];
+    if (!face) {
+        return YETTY_ERR(uint32, "ligature face has no regular style");
+    }
+    if (FT_Load_Glyph(face, gid, FT_LOAD_RENDER) != 0) {
+        return YETTY_ERR(uint32, "FT_Load_Glyph failed for ligature gid");
+    }
+    FT_GlyphSlot slot = face->glyph;
+    FT_Bitmap *bitmap = &slot->bitmap;
+
+    uint32_t slot_idx = (uint32_t)font->next_slot_idx;
+    size_t needed = (slot_idx + 1) * sizeof(struct yetty_yfont_raster_glyph_uv);
+    if (needed > FONT_UV_BUF(font).capacity) {
+        size_t new_cap = FONT_UV_BUF(font).capacity * 2;
+        if (new_cap < needed) {
+            new_cap = needed;
+        }
+        void *grown = realloc(FONT_UV_BUF(font).data, new_cap);
+        if (!grown) {
+            return YETTY_ERR(uint32, "ligature UV realloc failed");
+        }
+        FONT_UV_BUF(font).data = grown;
+        FONT_UV_BUF(font).capacity = new_cap;
+    }
+    if (needed > FONT_UV_BUF(font).size) {
+        FONT_UV_BUF(font).size = needed;
+    }
+    struct yetty_yfont_raster_glyph_uv *uvs = FONT_UVS(font);
+
+    int cell_w = (int)font->cell_width;
+    int cell_h = (int)font->cell_height;
+    uint32_t glyph_width = (uint32_t)cell_w * width_cells + RASTER_FONT_ATLAS_PADDING * 2;
+    uint32_t glyph_height = (uint32_t)cell_h + RASTER_FONT_ATLAS_PADDING * 2;
+    uint32_t aw = FONT_ATLAS(font).width;
+    uint32_t ah = FONT_ATLAS(font).height;
+    size_t atlas_size = (size_t)aw * ah;
+
+    if (font->shelf_x + glyph_width > aw) {
+        font->shelf_x = font->shelf_min_x + RASTER_FONT_ATLAS_PADDING;
+        font->shelf_y += font->shelf_height + RASTER_FONT_ATLAS_PADDING;
+        font->shelf_height = 0;
+    }
+    while (font->shelf_y + glyph_height > ah) {
+        uint32_t old_width = aw;
+        uint32_t old_height = ah;
+        raster_font_grow_atlas(font);
+        aw = FONT_ATLAS(font).width;
+        ah = FONT_ATLAS(font).height;
+        atlas_size = (size_t)aw * ah;
+        if (aw == old_width && ah == old_height) {
+            return YETTY_ERR(uint32, "atlas full, cannot fit ligature glyph");
+        }
+    }
+
+    uint32_t atlas_x = font->shelf_x;
+    uint32_t atlas_y = font->shelf_y;
+    uint8_t *pixels = FONT_ATLAS(font).data;
+
+    for (uint32_t y = 0; y < glyph_height; y++) {
+        for (uint32_t x = 0; x < glyph_width; x++) {
+            uint32_t dst_idx = (atlas_y + y) * aw + (atlas_x + x);
+            if (dst_idx < atlas_size) {
+                pixels[dst_idx] = 0u;
+            }
+        }
+    }
+
+    int glyph_w = (int)bitmap->width;
+    int glyph_h = (int)bitmap->rows;
+
+    int offset_x = slot->bitmap_left + RASTER_FONT_ATLAS_PADDING;
+    if (offset_x < RASTER_FONT_ATLAS_PADDING) {
+        offset_x = RASTER_FONT_ATLAS_PADDING;
+    }
+    if (glyph_w > 0 &&
+        offset_x > (int)(glyph_width - (uint32_t)glyph_w - RASTER_FONT_ATLAS_PADDING)) {
+        offset_x = (int)(glyph_width - (uint32_t)glyph_w - RASTER_FONT_ATLAS_PADDING);
+    }
+    if (offset_x < RASTER_FONT_ATLAS_PADDING) {
+        offset_x = RASTER_FONT_ATLAS_PADDING;
+    }
+
+    int offset_y = font->baseline - slot->bitmap_top + RASTER_FONT_ATLAS_PADDING;
+    if (offset_y < RASTER_FONT_ATLAS_PADDING) {
+        offset_y = RASTER_FONT_ATLAS_PADDING;
+    }
+    if (glyph_h > 0 &&
+        offset_y > (int)(glyph_height - (uint32_t)glyph_h - RASTER_FONT_ATLAS_PADDING)) {
+        offset_y = (int)(glyph_height - (uint32_t)glyph_h - RASTER_FONT_ATLAS_PADDING);
+    }
+    if (offset_y < RASTER_FONT_ATLAS_PADDING) {
+        offset_y = RASTER_FONT_ATLAS_PADDING;
+    }
+
+    /* Copy coverage bitmap into the slot, clipped to the slot box (a ligature
+     * antialiasing overhang must not bleed into the neighbouring slot). */
+    for (int y = 0; y < glyph_h; y++) {
+        if (offset_y + y >= (int)glyph_height) {
+            break;
+        }
+        for (int x = 0; x < glyph_w; x++) {
+            if (offset_x + x >= (int)glyph_width) {
+                break;
+            }
+            uint32_t dst_idx = (atlas_y + (uint32_t)offset_y + (uint32_t)y) * aw +
+                               (atlas_x + (uint32_t)offset_x + (uint32_t)x);
+            if (dst_idx < atlas_size) {
+                pixels[dst_idx] = bitmap->buffer[y * bitmap->pitch + x];
+            }
+        }
+    }
+
+    uvs[slot_idx].uv_x = (float)(atlas_x + RASTER_FONT_ATLAS_PADDING) / (float)aw;
+    uvs[slot_idx].uv_y = (float)(atlas_y + RASTER_FONT_ATLAS_PADDING) / (float)ah;
+    uvs[slot_idx].width_cells = (float)width_cells;
+    uvs[slot_idx].pad = 0.0f;
+
+    font->shelf_x = atlas_x + glyph_width + RASTER_FONT_ATLAS_PADDING;
+    if (glyph_height > font->shelf_height) {
+        font->shelf_height = glyph_height;
+    }
+
+    font->next_slot_idx++;
+    font->dirty = 1;
+    return YETTY_OK(uint32, slot_idx);
+}
+
+static struct uint32_result raster_font_get_glyph_index_ligature(struct yetty_yfont_ms_font *self,
+                                                                 const uint32_t *codepoints,
+                                                                 size_t count, uint32_t *out_slots)
+{
+    struct yetty_yfont_raster_font *font = container_of(self, struct yetty_yfont_raster_font, base);
+    if (!codepoints || !out_slots || count < 2u || count > YETTY_YFONT_LIGATURE_MAX_LEN) {
+        return YETTY_ERR(uint32, "invalid ligature run");
+    }
+
+    /* Steady-state fast path: the same ligature reappears every frame (the grid
+     * re-packs each visible row), so serve a known sequence from the cache
+     * without touching HarfBuzz or allocating a shaping buffer. */
+    for (size_t i = 0; i < font->ligature_slot_count; i++) {
+        const struct yetty_yfont_ligature_slot *entry = &font->ligature_slots[i];
+        if (entry->count != count) {
+            continue;
+        }
+        int same = 1;
+        for (size_t k = 0; k < count; k++) {
+            if (entry->codepoints[k] != codepoints[k]) {
+                same = 0;
+                break;
+            }
+        }
+        if (same) {
+            for (size_t k = 0; k < count; k++) {
+                out_slots[k] = entry->slots[k];
+            }
+            return YETTY_OK(uint32, (uint32_t)count);
+        }
+    }
+
+    hb_font_t *hb_font = raster_font_hb_font_get(font);
+    if (!hb_font) {
+        return YETTY_ERR(uint32, "harfbuzz font unavailable for ligature face");
+    }
+
+    hb_buffer_t *buffer = hb_buffer_create();
+    if (!buffer || !hb_buffer_allocation_successful(buffer)) {
+        if (buffer) {
+            hb_buffer_destroy(buffer);
+        }
+        return YETTY_ERR(uint32, "hb_buffer_create failed");
+    }
+    for (size_t i = 0; i < count; i++) {
+        hb_buffer_add(buffer, (hb_codepoint_t)codepoints[i], (unsigned)i);
+    }
+    hb_buffer_set_content_type(buffer, HB_BUFFER_CONTENT_TYPE_UNICODE);
+    hb_buffer_set_direction(buffer, HB_DIRECTION_LTR);
+    hb_buffer_set_script(buffer, HB_SCRIPT_LATIN);
+    /* Default features apply liga/calt — the programming ligatures live in the
+     * face's calt table. */
+    hb_shape(hb_font, buffer, NULL, 0);
+
+    unsigned glyph_count = 0;
+    hb_glyph_info_t *infos = hb_buffer_get_glyph_infos(buffer, &glyph_count);
+    /* Monospace ligature fonts substitute each cell's character with a
+     * ligature-piece glyph and keep the glyph count equal to the cell count
+     * (each piece advances one cell). If the run did not shape one-glyph-per-
+     * cell, treat it as non-ligating and let the grid draw the characters
+     * individually. */
+    if (!infos || glyph_count != count) {
+        hb_buffer_destroy(buffer);
+        return YETTY_ERR(uint32, "run does not shape to one glyph per cell");
+    }
+    uint32_t gids[YETTY_YFONT_LIGATURE_MAX_LEN];
+    for (size_t i = 0; i < count; i++) {
+        gids[i] = infos[i].codepoint; /* after shaping, .codepoint holds the gid */
+    }
+    hb_buffer_destroy(buffer);
+
+    /* Rasterize each cell's component glyph (width 1) into the atlas. */
+    uint32_t new_slots[YETTY_YFONT_LIGATURE_MAX_LEN];
+    for (size_t i = 0; i < count; i++) {
+        if (gids[i] == 0u) {
+            return YETTY_ERR(uint32, "ligature component resolved to notdef");
+        }
+        struct uint32_result slot_res =
+            raster_font_rasterize_ligature_gid(font, (FT_UInt)gids[i], 1u);
+        if (YETTY_IS_ERR(slot_res)) {
+            return slot_res;
+        }
+        new_slots[i] = slot_res.value;
+    }
+
+    if (font->ligature_slot_count >= font->ligature_slot_capacity) {
+        size_t new_cap = font->ligature_slot_capacity ? font->ligature_slot_capacity * 2 : 32;
+        struct yetty_yfont_ligature_slot *grown =
+            realloc(font->ligature_slots, new_cap * sizeof(struct yetty_yfont_ligature_slot));
+        if (!grown) {
+            return YETTY_ERR(uint32, "ligature slot cache realloc failed");
+        }
+        font->ligature_slots = grown;
+        font->ligature_slot_capacity = new_cap;
+    }
+    struct yetty_yfont_ligature_slot *new_entry = &font->ligature_slots[font->ligature_slot_count];
+    for (size_t k = 0; k < count; k++) {
+        new_entry->codepoints[k] = codepoints[k];
+        new_entry->slots[k] = new_slots[k];
+        out_slots[k] = new_slots[k];
+    }
+    new_entry->count = (uint8_t)count;
+    font->ligature_slot_count++;
+    return YETTY_OK(uint32, (uint32_t)count);
+}
+#else  /* !YETTY_ENABLE_LIB_HARFBUZZ */
+static struct uint32_result raster_font_get_glyph_index_ligature(struct yetty_yfont_ms_font *self,
+                                                                 const uint32_t *codepoints,
+                                                                 size_t count, uint32_t *out_slots)
+{
+    (void)self;
+    (void)codepoints;
+    (void)count;
+    (void)out_slots;
+    return YETTY_ERR(uint32, "ligature shaping requires HarfBuzz");
+}
+#endif /* YETTY_ENABLE_LIB_HARFBUZZ */
+
 static void raster_font_cleanup(struct yetty_yfont_raster_font *font)
 {
+#ifdef YETTY_ENABLE_LIB_HARFBUZZ
+    if (font->hb_font) {
+        hb_font_destroy((hb_font_t *)font->hb_font);
+        font->hb_font = NULL;
+    }
+    free(font->ligature_slots);
+    font->ligature_slots = NULL;
+    font->ligature_slot_count = 0;
+    font->ligature_slot_capacity = 0;
+#endif
     for (int i = 0; i < 4; i++) {
         if (font->ft_faces[i]) {
             FT_Done_Face(font->ft_faces[i]);
@@ -1139,6 +1530,19 @@ struct yetty_font_ms_font_result yetty_yfont_ms_raster_font_create(
 struct yetty_font_ms_font_result yetty_yfont_ms_raster_font_create_named(
     struct yetty_yconfig_config *config, const char *font_name, float cell_width, float cell_height)
 {
+    return raster_font_create_named_impl(config, font_name, cell_width, cell_height, 0);
+}
+
+struct yetty_font_ms_font_result yetty_yfont_ms_raster_font_create_ligature(
+    struct yetty_yconfig_config *config, const char *font_name, float cell_width, float cell_height)
+{
+    return raster_font_create_named_impl(config, font_name, cell_width, cell_height, 1);
+}
+
+static struct yetty_font_ms_font_result raster_font_create_named_impl(
+    struct yetty_yconfig_config *config, const char *font_name, float cell_width, float cell_height,
+    int size_to_cell_width)
+{
     const char *fonts_dir = config->ops->get_string(config, "paths/fonts", "");
     const char *shaders_dir = config->ops->get_string(config, "paths/shaders", "");
     const char *font_family = font_name;
@@ -1262,6 +1666,7 @@ struct yetty_font_ms_font_result yetty_yfont_ms_raster_font_create_named(
         font->atlas_bpp = 1;
     }
 
+    font->size_to_cell_width = size_to_cell_width;
     raster_font_update_font_size(font);
 
     /* Shelf packer */

--- a/src/yetty/yvterm/grid-sdf-layer.c
+++ b/src/yetty/yvterm/grid-sdf-layer.c
@@ -50,8 +50,6 @@
 #include <yetty/ytrace/ytrace.h>
 #include "yetty/gen/impl/yvterm/grid.h"
 
-#include "ligature-cells.h"
-
 /* GLYPH primitive type — matches the shader's YDRAW_SDF_GLYPH (and ygrid). */
 #define YVTERM_SDF_GLYPH_TYPE 200u
 
@@ -1011,14 +1009,6 @@ static struct sdf_shaping_face *sdf_shaping_face_for(struct yetty_yvterm_sdf_lay
     return sdf_face_load_or_get(layer, file);
 }
 
-/* The bundled programming-ligature face (Fira Code), loaded on the first
- * ligature seen. Staged unconditionally in assets/fonts, so it is present in
- * any build that defines YETTY_ENABLE_LIB_HARFBUZZ. */
-static struct sdf_shaping_face *sdf_ligature_face(struct yetty_yvterm_sdf_layer *layer)
-{
-    return sdf_face_load_or_get(layer, "FiraCode-Regular.ttf");
-}
-
 /* Scan one terminal row's cells for complex-script runs and emit shaped glyphs
  * for each over the cells' positions. The grid suppresses those cells' glyphs
  * (vterm_pack_line), so this is the only glyph drawn there. Called per window
@@ -1093,82 +1083,6 @@ static struct yetty_ycore_void_result shape_row_cells(struct yetty_yvterm_sdf_la
     return YETTY_OK_VOID();
 }
 
-/* Scan one terminal row's cells for programming-ligature spans (=>, !=, ===)
- * and draw each as a shaped glyph over its cells with the Fira Code face. The
- * grid suppresses the same spans (vterm_pack_line calls the identical
- * yetty_yvterm_ligature_run_length), so this is the only glyph drawn there.
- * Complex-script cells never match the ASCII-only ligature table, so the two
- * shaping passes cover disjoint cells. */
-static struct yetty_ycore_void_result shape_row_ligatures(struct yetty_yvterm_sdf_layer *layer,
-                                                          struct yetty_yclass_object *grid_obj,
-                                                          uint32_t slot, float cell_width,
-                                                          float cell_height, uint32_t cols)
-{
-    struct yetty_yvterm_text_cell_const_ptr_result cells_res =
-        yetty_yvterm_grid_slot_cells(grid_obj, slot);
-    if (YETTY_IS_ERR(cells_res)) {
-        yetty_ycore_error_destroy(cells_res.error);
-        return YETTY_OK_VOID();
-    }
-    const struct yetty_yvterm_text_cell *cells = cells_res.value;
-    if (!cells) {
-        return YETTY_OK_VOID();
-    }
-
-    struct sdf_shaping_face *face = NULL; /* loaded lazily on the first ligature */
-
-    uint32_t col = 0;
-    while (col < cols) {
-        size_t ligature_len = yetty_yvterm_ligature_run_length(cells, cols, col);
-        if (ligature_len < 2u) {
-            col++;
-            continue;
-        }
-
-        if (!face) {
-            face = sdf_ligature_face(layer);
-        }
-        if (!face) {
-            /* Ligature font unavailable this frame — the grid already suppressed
-             * these cells, so nothing more to try; skip past the span. */
-            col += (uint32_t)ligature_len;
-            continue;
-        }
-
-        uint32_t run_codepoints[YETTY_YFONT_LIGATURE_MAX_LEN];
-        for (size_t offset = 0; offset < ligature_len; offset++) {
-            run_codepoints[offset] = cells[col + offset].codepoint;
-        }
-
-        /* Scale the monospace ligature face so one character advance equals the
-         * grid cell width: the ligature's own advance then spans exactly its
-         * cells, and any non-ligated fallback glyphs stay cell-aligned too. */
-        float base_size = face->font->ops->get_base_size(face->font);
-        float advance_base = base_size * 0.6f;
-        struct float_result adv_res =
-            face->font->ops->get_advance(face->font, (uint32_t)'M', base_size);
-        if (YETTY_IS_OK(adv_res) && adv_res.value > 0.0f) {
-            advance_base = adv_res.value;
-        }
-        float font_size = cell_width * base_size / advance_base;
-
-        struct sdf_shaped_run_style style = {
-            .layer_id = 0u,
-            .color = (cells[col].fg & 0x00FFFFFFu) | 0xFF000000u,
-            .font_size = font_size,
-            .base_size = base_size,
-            .char_spacing = 0.0f,
-            .baseline_y = cell_height * 0.75f,
-        };
-        float cursor_x = (float)col * cell_width;
-        struct yetty_ycore_void_result er = emit_shaped_glyphs(
-            layer, face->font, face->slot, run_codepoints, ligature_len, &style, &cursor_x);
-        YETTY_RETURN_IF_ERR(yetty_ycore_void, er, "sdf-layer: shape row ligatures");
-
-        col += (uint32_t)ligature_len;
-    }
-    return YETTY_OK_VOID();
-}
 #endif /* YETTY_ENABLE_LIB_HARFBUZZ */
 
 /* Expand a TEXT_DRAWABLE_LIST into one GLYPH record per codepoint, anchored at
@@ -1574,15 +1488,13 @@ struct yetty_ycore_void_result yetty_yvterm_sdf_layer_render(
         }
 #ifdef YETTY_ENABLE_LIB_HARFBUZZ
         /* Shape any complex-script runs in this row's terminal cells. The grid
-         * suppresses those cells' own glyphs, so this draws them shaped. */
+         * suppresses those cells' own glyphs, so this draws them shaped.
+         * (Programming ligatures are NOT handled here: they are cell-aligned
+         * N-wide glyphs drawn directly by the grid shader — see vterm.c
+         * vterm_pack_line + grid-text.wgsl.) */
         struct yetty_ycore_void_result shape_res =
             shape_row_cells(layer, grid_obj, slot, cell_width, cell_height, cols);
         YETTY_RETURN_IF_ERR(yetty_ycore_void, shape_res, "sdf-layer: shape row cells");
-        /* Draw programming ligatures (=>, !=, ===) for this row's cells; the
-         * grid suppresses the same spans (identical ligature-run decision). */
-        struct yetty_ycore_void_result lig_res =
-            shape_row_ligatures(layer, grid_obj, slot, cell_width, cell_height, cols);
-        YETTY_RETURN_IF_ERR(yetty_ycore_void, lig_res, "sdf-layer: shape row ligatures");
 #endif
     }
     ydebug("sdf-layer: render prim_count=%u font_count=%u rows=%u cols=%u", layer->prim_count,

--- a/src/yetty/yvterm/grid-text.wgsl
+++ b/src/yetty/yvterm/grid-text.wgsl
@@ -40,7 +40,7 @@ struct Uniforms {
     coord_fx_p3: f32, coord_fx_p4: f32, coord_fx_p5: f32,
     pad_a: u32, pad_b: u32,
     face_methods: u32, face_pad0: u32, face_pad1: u32, face_pad2: u32,
-    face_params: array<vec4<f32>, 4>,
+    face_params: array<vec4<f32>, 6>,
 };
 @group(0) @binding(0) var<storage, read> cells: array<u32>;
 @group(0) @binding(1) var<storage, read> glyph_meta: array<u32>;
@@ -56,6 +56,10 @@ struct Uniforms {
 @group(0) @binding(8) var face2_tex: texture_2d<f32>;
 @group(0) @binding(9) var<storage, read> face3_meta: array<u32>;
 @group(0) @binding(10) var face3_tex: texture_2d<f32>;
+@group(0) @binding(11) var<storage, read> face4_meta: array<u32>;
+@group(0) @binding(12) var face4_tex: texture_2d<f32>;
+@group(0) @binding(13) var<storage, read> face5_meta: array<u32>;
+@group(0) @binding(14) var face5_tex: texture_2d<f32>;
 struct VSOut {
     @builtin(position) pos: vec4<f32>,
     @location(0) @interpolate(linear) grid_pixel: vec2<f32>,
@@ -81,6 +85,8 @@ fn face_meta(face: u32, index: u32) -> u32 {
         case 1u: { return face1_meta[index]; }
         case 2u: { return face2_meta[index]; }
         case 3u: { return face3_meta[index]; }
+        case 4u: { return face4_meta[index]; }
+        case 5u: { return face5_meta[index]; }
         default: { return glyph_meta[index]; }
     }
 }
@@ -89,6 +95,8 @@ fn face_texel(face: u32, uv: vec2<f32>) -> vec4<f32> {
         case 1u: { return textureSampleLevel(face1_tex, atlas_smp, uv, 0.0); }
         case 2u: { return textureSampleLevel(face2_tex, atlas_smp, uv, 0.0); }
         case 3u: { return textureSampleLevel(face3_tex, atlas_smp, uv, 0.0); }
+        case 4u: { return textureSampleLevel(face4_tex, atlas_smp, uv, 0.0); }
+        case 5u: { return textureSampleLevel(face5_tex, atlas_smp, uv, 0.0); }
         default: { return textureSampleLevel(atlas_tex, atlas_smp, uv, 0.0); }
     }
 }
@@ -97,6 +105,8 @@ fn face_atlas_size(face: u32) -> vec2<f32> {
         case 1u: { return vec2<f32>(textureDimensions(face1_tex)); }
         case 2u: { return vec2<f32>(textureDimensions(face2_tex)); }
         case 3u: { return vec2<f32>(textureDimensions(face3_tex)); }
+        case 4u: { return vec2<f32>(textureDimensions(face4_tex)); }
+        case 5u: { return vec2<f32>(textureDimensions(face5_tex)); }
         default: { return vec2<f32>(textureDimensions(atlas_tex)); }
     }
 }

--- a/src/yetty/yvterm/vterm.c
+++ b/src/yetty/yvterm/vterm.c
@@ -70,7 +70,15 @@ enum { YVTERM_GLYPH_TOFU = 0xFFFFFFFFu };
  * shader picks the face per cell (packed next to the cell width) and decodes
  * per the face's render method.
  *=========================================================================*/
-enum { YVTERM_MAX_FONT_FACES = 4 };
+/* Face 0 = base font; face 1 = the bundled programming-ligature face (Fira
+ * Code, present only when the shaper is built in); faces 2+ = config range
+ * faces (CJK/emoji/…). Sized so a realistic config (base + ligature + a few
+ * ranges) never evicts the ligature slot. Each face costs two shader bindings,
+ * so the count also sizes the bind-group arrays below. */
+enum { YVTERM_MAX_FONT_FACES = 6 };
+/* Fixed bindings 0..4 (cells, base meta, base atlas, sampler, uniforms) plus
+ * two per extra face (meta buffer + atlas texture). */
+enum { YVTERM_BIND_ENTRY_COUNT = 5 + 2 * (YVTERM_MAX_FONT_FACES - 1) };
 enum { YVTERM_MAX_FONT_RANGES = 64 };
 enum { YVTERM_FONT_FACE_NAME_MAX = 64 };
 
@@ -271,6 +279,10 @@ struct YETTY_ANNOTATE("class@yvterm:vterm") YETTY_ANNOTATE("parent@yfigure:figur
      * codepoint→face routing table is matched in config order at pack time. */
     struct yvterm_font_face faces[YVTERM_MAX_FONT_FACES];
     uint32_t face_count;
+    /* Index into faces[] of the bundled programming-ligature face (Fira Code),
+     * or 0 when none is loaded (0 is always the base font, never a ligature
+     * face, so 0 unambiguously means "no ligature face"). */
+    uint32_t ligature_face_index;
     struct yvterm_font_range font_ranges[YVTERM_MAX_FONT_RANGES];
     uint32_t font_range_count;
 
@@ -405,9 +417,15 @@ static void vterm_pack_line(struct yetty_yvterm_vterm *vterm,
                             uint32_t *out)
 {
 #ifdef YETTY_ENABLE_LIB_HARFBUZZ
-    /* Cells still covered by a programming ligature the SDF layer draws over
-     * the grid (see ligature-cells.h). Counts down across the span. */
-    uint32_t ligature_remaining = 0u;
+    /* Programming-ligature span state. A monospace ligature shapes to one
+     * substituted component glyph per cell (Fira Code's calt pieces that tile
+     * into the ligature), so each covered cell gets its own ordinary width-1
+     * glyph from the ligature face — no wide/spill glyph, and the ligature
+     * inverts/selects/scrolls like any other grid text. */
+    uint32_t ligature_remaining = 0u; /* cells left in the current span */
+    uint32_t ligature_index = 0u;     /* index of the next cell's component slot */
+    uint32_t ligature_face = 0u;      /* face the components live in */
+    uint32_t ligature_slots[YETTY_YFONT_LIGATURE_MAX_LEN];
 #endif
     for (uint32_t col = 0; col < cols; ++col) {
         const struct yetty_yvterm_text_cell *cell = &cells[col];
@@ -417,18 +435,37 @@ static void vterm_pack_line(struct yetty_yvterm_vterm *vterm,
         uint32_t face = 0u;
         int resolve_glyph = cell->codepoint && !(cell->attrs & YETTY_YVTERM_ATTR_CONCEAL);
 #ifdef YETTY_ENABLE_LIB_HARFBUZZ
+        /* Start of a ligature run: shape it and stash the per-cell component
+         * glyphs. Consumed cell-by-cell just below. */
+        if (ligature_remaining == 0u && resolve_glyph && vterm->ligature_face_index) {
+            size_t ligature_len = yetty_yvterm_ligature_run_length(cells, cols, col);
+            struct yetty_yfont_ms_font *ligfont =
+                ligature_len >= 2u ? vterm->faces[vterm->ligature_face_index].font : NULL;
+            if (ligfont && ligfont->ops->get_glyph_index_ligature) {
+                uint32_t seq[YETTY_YFONT_LIGATURE_MAX_LEN];
+                for (size_t k = 0; k < ligature_len; ++k) {
+                    seq[k] = cells[col + k].codepoint;
+                }
+                struct uint32_result lig_res = ligfont->ops->get_glyph_index_ligature(
+                    ligfont, seq, ligature_len, ligature_slots);
+                if (YETTY_IS_OK(lig_res)) {
+                    ligature_remaining = (uint32_t)ligature_len;
+                    ligature_index = 0u;
+                    ligature_face = vterm->ligature_face_index;
+                } else {
+                    /* Sequence does not ligate in the face — draw the operator
+                     * characters individually (fall through to normal resolve). */
+                    yetty_ycore_error_destroy(lig_res.error);
+                }
+            }
+        }
         if (ligature_remaining > 0u) {
-            /* Interior cell of a programming ligature: the SDF layer shapes the
-             * whole ligature and draws its glyph on top, so paint background
-             * only here — same contract as complex-script / shader-glyph cells. */
+            /* Cell of a ligature run: draw its component glyph (an ordinary
+             * width-1 grid glyph) from the ligature face. */
+            glyph = ligature_slots[ligature_index++];
+            face = ligature_face;
             ligature_remaining--;
             resolve_glyph = 0;
-        } else if (resolve_glyph) {
-            size_t ligature_len = yetty_yvterm_ligature_run_length(cells, cols, col);
-            if (ligature_len >= 2u) {
-                ligature_remaining = (uint32_t)(ligature_len - 1u);
-                resolve_glyph = 0;
-            }
         }
 #endif
         if (resolve_glyph) {
@@ -581,7 +618,7 @@ static struct yetty_ycore_void_result vterm_create_pipeline(struct yetty_yvterm_
         return YETTY_ERR(yetty_ycore_void, "vterm: shader module");
     }
 
-    WGPUBindGroupLayoutEntry entries[11] = {0};
+    WGPUBindGroupLayoutEntry entries[YVTERM_BIND_ENTRY_COUNT] = {0};
     entries[0].binding = 0;
     entries[0].visibility = WGPUShaderStage_Fragment;
     entries[0].buffer.type = WGPUBufferBindingType_ReadOnlyStorage;
@@ -610,7 +647,7 @@ static struct yetty_ycore_void_result vterm_create_pipeline(struct yetty_yvterm_
         entries[4 + i * 2].texture.viewDimension = WGPUTextureViewDimension_2D;
     }
     WGPUBindGroupLayoutDescriptor bgl_desc = {0};
-    bgl_desc.entryCount = 11;
+    bgl_desc.entryCount = YVTERM_BIND_ENTRY_COUNT;
     bgl_desc.entries = entries;
     vterm->bind_group_layout = wgpuDeviceCreateBindGroupLayout(vterm->device, &bgl_desc);
     if (!vterm->bind_group_layout) {
@@ -884,7 +921,7 @@ static struct yetty_ycore_void_result vterm_ensure_bind_group(struct yetty_yvter
         !vterm->uniform_buffer) {
         return YETTY_ERR(yetty_ycore_void, "vterm_ensure_bind_group: missing resource");
     }
-    WGPUBindGroupEntry entries[11] = {0};
+    WGPUBindGroupEntry entries[YVTERM_BIND_ENTRY_COUNT] = {0};
     entries[0].binding = 0;
     entries[0].buffer = vterm->cell_buffer;
     entries[0].size = WGPU_WHOLE_SIZE;
@@ -911,7 +948,7 @@ static struct yetty_ycore_void_result vterm_ensure_bind_group(struct yetty_yvter
     }
     WGPUBindGroupDescriptor bg_desc = {0};
     bg_desc.layout = vterm->bind_group_layout;
-    bg_desc.entryCount = 11;
+    bg_desc.entryCount = YVTERM_BIND_ENTRY_COUNT;
     bg_desc.entries = entries;
     vterm->bind_group = wgpuDeviceCreateBindGroup(vterm->device, &bg_desc);
     if (!vterm->bind_group) {
@@ -1036,6 +1073,43 @@ static uint32_t vterm_face_find_or_create(struct yetty_yvterm_vterm *vterm,
     }
     return index;
 }
+
+#ifdef YETTY_ENABLE_LIB_HARFBUZZ
+/* Load the bundled programming-ligature face (Fira Code) into a dedicated grid
+ * face right after the base font — before the config range faces, so it always
+ * keeps its slot. A ligature run is then drawn as ONE N-wide grid glyph from
+ * this face (vterm_pack_line resolves it via get_glyph_index_ligature; the
+ * grid shader's wide-glyph spill draws it across the covered cells). Sized so
+ * one character advance equals the cell width, so a ligature spans exactly its
+ * N cells. Best-effort: on any failure ligatures stay off and the grid renders
+ * the operator characters individually. Sets vterm->ligature_face_index. */
+static void vterm_load_ligature_face(struct yetty_yvterm_vterm *vterm,
+                                     struct yetty_yconfig_config *config)
+{
+    if (!config || vterm->face_count == 0u || vterm->face_count >= YVTERM_MAX_FONT_FACES) {
+        return;
+    }
+    struct pixel_size_result cell = vterm->faces[0].font->ops->get_cell_size(vterm->faces[0].font);
+    if (YETTY_IS_ERR(cell)) {
+        yetty_ycore_error_destroy(cell.error);
+        return;
+    }
+    struct yetty_font_ms_font_result font_res = yetty_yfont_ms_raster_font_create_ligature(
+        config, "FiraCode", cell.value.width, cell.value.height);
+    if (YETTY_IS_ERR(font_res)) {
+        ywarn("vterm: ligature face (FiraCode) not loaded, ligatures disabled: %s",
+              font_res.error.msg);
+        yetty_ycore_error_destroy(font_res.error);
+        return;
+    }
+    uint32_t index = vterm->face_count++;
+    struct yvterm_font_face *face = &vterm->faces[index];
+    face->font = font_res.value;
+    face->method = YVTERM_FONT_METHOD_RASTER; /* Fira Code is monochrome (R8) */
+    strncpy(face->name, "FiraCode-ligatures", YVTERM_FONT_FACE_NAME_MAX - 1);
+    vterm->ligature_face_index = index;
+}
+#endif
 
 /* Build the codepoint-range → face routing table from the config list
  * (terminal/text-layer/font/ranges: {from, to, font, render-method}). */
@@ -1181,6 +1255,12 @@ static struct yetty_ycore_void_result vterm_gpu_init(struct yetty_yvterm_vterm *
     if (YETTY_IS_OK(cell)) {
         vterm->cell_size = cell.value;
     }
+
+#ifdef YETTY_ENABLE_LIB_HARFBUZZ
+    /* Programming-ligature face (face 1) — loaded before the range faces so it
+     * keeps a dedicated slot regardless of how many ranges the config adds. */
+    vterm_load_ligature_face(vterm, config);
+#endif
 
     /* Config codepoint-range faces (CJK/emoji/etc.) — created after the base
      * font so raster faces inherit its cell size. Best-effort: a face that


### PR DESCRIPTION
Programming ligatures (=>, !=, ===, ...) were drawn through the SDF free-position layer — the machinery built for complex-script shaping (Arabic joining, Indic reordering). But a monospace ligature is cell-aligned by construction and needs none of that: routing it through a second render pass cost a per-face binder namespace, a draw-time width-scaling hack, a fragile two-pass "agree without communicating" contract between the grid suppression and the SDF redraw, and — because the SDF glyph was overlaid in a fixed fg colour — ligatures that did not invert under the block cursor, highlight under selection, or compose with the grid's colour effects.

Draw them in the grid's own pass instead. A monospace ligature font keeps one glyph per input cell: Fira Code's calt substitutes each operator character with a ligature-piece glyph that tiles with its neighbours (-> becomes an extended bar + an arrowhead, one per cell; === three pieces). So each covered cell simply gets its own substituted glyph — an ordinary width-1 grid glyph — and the ligature inverts, selects, and scrolls like any other grid text, for free.

- ms-font: new get_glyph_index_ligature op. The raster backend shapes the run through the face's GSUB/calt tables with HarfBuzz (standalone FT/HB over the SFNT tables), requires one glyph per cell, rasterizes each component gid at width 1, and returns the per-cell atlas slots. Cached by codepoint sequence so the steady state (the grid re-packs every visible row each frame) is a linear-scan hit with no reshaping. Left NULL by the MSDF backend, which has no live rasterizer.
- ms-raster-font: a size_to_cell_width mode sizes the face so one advance equals the cell width, so each piece fills exactly one cell and following text stays aligned.
- vterm: load Fira Code as a dedicated grid raster face (before the config range faces so it keeps its slot); face budget raised to leave headroom. vterm_pack_line assigns each ligature cell its component glyph.
- Delete shape_row_ligatures + sdf_ligature_face from the SDF layer; the complex-script shaping pass stays (it genuinely needs free positioning).

The HarfBuzz-free detection table (yfont/ligature.c) and the shared cell-level decision (yvterm/ligature-cells.h) are unchanged. Gated on YETTY_ENABLE_LIB_HARFBUZZ; without it the face is never loaded and the operators render individually. Verified live via
demo/scripts/harfbuzz/ligatures.sh; yfont_ligature test still green.